### PR TITLE
Get datetimeindex for hierarchical clustering

### DIFF
--- a/example/script_example.py
+++ b/example/script_example.py
@@ -1,0 +1,25 @@
+import tsam.timeseriesaggregation as tsam
+import pandas as pd
+
+raw = pd.read_csv('testdata.csv', index_col=0)
+
+aggregation = tsam.TimeSeriesAggregation(raw, noTypicalPeriods = 8,
+                                         hoursPerPeriod = 24,
+                                         clusterMethod = 'hierarchical')
+df = aggregation.createTypicalPeriods()
+weights = aggregation.clusterPeriodNoOccur
+aggregation.clusterOrder
+
+timesteps = [i for i in range(0, len(df.index.get_level_values('TimeStep')))]
+
+print(aggregation.clusterCenterIndices)
+
+# get all index for every hour that in day of the clusterCenterIndices
+days = [d for d in raw.index.dayofyear
+        if d in aggregation.clusterCenterIndices]
+
+# select the dates based on this
+dates = raw.iloc[days].index
+
+# TODO: Check index start (1 in dataframe, 0 in numpy -> should fit, otherwise
+# days are offset one day

--- a/tsam/timeseriesaggregation.py
+++ b/tsam/timeseriesaggregation.py
@@ -76,6 +76,12 @@ def aggregatePeriods(candidates, n_clusters=8,
         Chosen clustering algorithm. Possible values are 
         'averaging','k_means','exact k_medoid' or 'hierarchical'
     '''
+
+    if clusterMethod == 'hierarchical':
+        clusterCenterIndices = []
+    else:
+        clusterCenterIndices = None
+
     # cluster the data
     if clusterMethod == 'averaging':
         n_sets = len(candidates)
@@ -132,8 +138,9 @@ def aggregatePeriods(candidates, n_clusters=8,
             innerDistMatrix = euclidean_distances(candidates[indice])
             mindistIdx = np.argmin(innerDistMatrix.sum(axis=0))
             clusterCenters.append(candidates[indice][mindistIdx])
+            clusterCenterIndices.append(indice[0][mindistIdx])
 
-    return clusterCenters, clusterOrder
+    return clusterCenters, clusterCenterIndices, clusterOrder
 
 
 
@@ -702,7 +709,7 @@ class TimeSeriesAggregation(object):
         distanceMedoid_iter = []
 
         for i in range(n_init):
-            altClusterCenters, clusterOrders_C = aggregatePeriods(
+            altClusterCenters, clusterCenterIndices, clusterOrders_C = aggregatePeriods(
                 sortedClusterValues, n_clusters=self.noTypicalPeriods, n_iter=30,
                 clusterMethod = self.clusterMethod)
 
@@ -784,7 +791,8 @@ class TimeSeriesAggregation(object):
         cluster_duration = time.time()
         if not self.sortValues:
             # cluster the data
-            self.clusterCenters, self.clusterOrder = aggregatePeriods(
+            self.clusterCenters, self.clusterCenterIndices, \
+                self.clusterOrder = aggregatePeriods(
                 candidates, n_clusters=self.noTypicalPeriods, n_iter=100,
                 clusterMethod=self.clusterMethod)
         else:


### PR DESCRIPTION
Referring to #5 it would be nice to receive information about the original time index (datetimeindex) of the clustered days, when using hierarchical clustering. 

We did creat a [fork of tsam](https://github.com/openego/tsam) and added a new functionality 'clusterCentersIndices', which gives us the indices of the cluster centers (which are used as medoids). 

The example  ['Add scrict example' ](https://github.com/openego/tsam/commit/c653c43bf1b877c674fe1e71b9c171f35017ecd5) shows how it can be applied to receive the corresponding datetimeindex of the original data. 

Could you check out this new functionality? Would it be possible to implement it in the original tsam repository? 