### PR TITLE
Add the option of a clustering just adjacent periods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(dir_path,'README.md'), "r") as fh:
 
 setuptools.setup(
     name='tsam',
-    version='0.9.9',
+    version='1.0.0',
     author='Leander Kotzur',
     author_email='l.kotzur@fz-juelich.de',
     description='Time series aggregation module (tsam) to create typical periods',


### PR DESCRIPTION
It would be useful to be able to add the restriction that the hierarchical clustering just clusters adjacent periods. It is, for instance, the method used in the article [Pineda, Salvador, and Juan Miguel Morales. "Chronological time-period clustering for optimal capacity expansion planning with storage." IEEE Transactions on Power Systems (2018)] just for hourly periods. The only thing to modify is to add the connectivity matrix. Here is what I suggest: Add a Boolean parameter called "adjacent" and modify the "aggregatePeriods" in the "tsam.TimeSeriesAggregation" as follows:

```
    elif clusterMethod == 'hierarchical':
        from sklearn.cluster import AgglomerativeClustering
        ### Will cluster adjacent hours
        connectivity = []
        if adjacent == 'True':
           T=len(candidates)
           for i in range(T):
               vector=[]
               for j in range(T):
                   if j==(i+1)%T or j==(i-1)%T:
                       vector.append(1)
                   else:
                       vector.append(0)
               connectivity.append(vector)
        
        clustering = AgglomerativeClustering(
            n_clusters=n_clusters, linkage='ward',connectivity=connectivity)

``` 