### PR TITLE
Vectorization & MultiIndices

### DIFF
--- a/tsam/timeseriesaggregation.py
+++ b/tsam/timeseriesaggregation.py
@@ -414,19 +414,15 @@ class TimeSeriesAggregation(object):
         ---------
         normalized time series
         '''
-        normalizedTimeSeries = pd.DataFrame()
-        for column in self.timeSeries:
-            if not self.timeSeries[column].max() == self.timeSeries[column].min():  # ignore constant timeseries
-                normalizedTimeSeries[column] = (
-                                                   self.timeSeries[column] -
-                                                   self.timeSeries[column].min()) / \
-                                               (self.timeSeries[column].max() -
-                                                self.timeSeries[column].min())
-                if sameMean:
-                    normalizedTimeSeries[column] = normalizedTimeSeries[
-                                                       column] / normalizedTimeSeries[column].mean()
-            else:
-                normalizedTimeSeries[column] = self.timeSeries[column]
+        from sklearn import preprocessing
+        min_max_scaler = preprocessing.MinMaxScaler()
+        normalizedTimeSeries = pd.DataFrame(min_max_scaler.fit_transform(self.timeSeries),
+                                            columns=self.timeSeries.columns,
+                                            index=self.timeSeries.index)
+
+        if sameMean:
+            normalizedTimeSeries /= normalizedTimeSeries.mean()
+
         return normalizedTimeSeries
 
     def _unnormalizeTimeSeries(self, normalizedTimeSeries, sameMean=False):

--- a/tsam/timeseriesaggregation.py
+++ b/tsam/timeseriesaggregation.py
@@ -465,7 +465,7 @@ class TimeSeriesAggregation(object):
         puts them into the correct matrix format.
         '''
         # first sort the time series in order to avoid bug mention in #18
-        self.timeSeries = self.timeSeries.reindex(sorted(self.timeSeries.columns), axis=1)
+        self.timeSeries.sort_index(axis=1, inplace=True)
 
         # normalize the time series and group them to periodly profiles
         self.normalizedTimeSeries = self._normalizeTimeSeries(

--- a/tsam/timeseriesaggregation.py
+++ b/tsam/timeseriesaggregation.py
@@ -437,26 +437,17 @@ class TimeSeriesAggregation(object):
         sameMean: boolean, optional (default: False)
             Has to have the same value as in _normalizeTimeSeries.
         '''
-        unnormalizedTimeSeries = pd.DataFrame()
-        for column in self.timeSeries:
-            if not self.timeSeries[column].max() == self.timeSeries[column].min():  # ignore constant timeseries
-                if sameMean:
-                    unnormalizedTimeSeries[column] = \
-                        normalizedTimeSeries[column] * \
-                        (self.timeSeries[column].mean() -
-                         self.timeSeries[column].min()) / \
-                        (self.timeSeries[column].max() -
-                         self.timeSeries[column].min())
-                else:
-                    unnormalizedTimeSeries[
-                        column] = normalizedTimeSeries[column]
-                unnormalizedTimeSeries[column] = \
-                    unnormalizedTimeSeries[column] * \
-                    (self.timeSeries[column].max() -
-                     self.timeSeries[column].min()) + \
-                    self.timeSeries[column].min()
-            else:
-                unnormalizedTimeSeries[column] = normalizedTimeSeries[column]
+        from sklearn import preprocessing
+        min_max_scaler = preprocessing.MinMaxScaler()
+        min_max_scaler.fit(self.timeSeries)
+        unnormalizedTimeSeries = pd.DataFrame(min_max_scaler.inverse_transform(
+            normalizedTimeSeries),
+            columns=normalizedTimeSeries.columns,
+            index=normalizedTimeSeries.index)
+
+        if sameMean:
+            unnormalizedTimeSeries *= unnormalizedTimeSeries.mean()
+
         return unnormalizedTimeSeries
 
     def _preProcessTimeSeries(self):


### PR DESCRIPTION
Hi guys,
I love this package of yours and would like to contribute two little changes that improved my workflow while using TSAM.

First of all, in terms of speed, because of the general use in this package of loops to build DataFrames, it seems that some methods suffer with speed problems. Many [authors](https://engineering.upside.com/a-beginners-guide-to-optimizing-pandas-code-for-speed-c09ef2c6a4d6) suggest to use vectorization which can drastically improve some workflows. I added such an example in `_normalizeTimeSeries` by using the sklearn vectorized [min_max_scaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html) function. I suggest you try to gradually remove all the loops and replace them with vectorized version whenever possible :)

Second, I encountered an issue when there are column MultiIndexes in the original time series DataFrame. The error happens in `_preProcessTimeSeries` and is due to the `sorted()` method that breaks the column MultiIndex. The simplest fix is to use the [sort_index](https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.DataFrame.sort_index.html#pandas.DataFrame.sort_index) method which can handle MultIndexes.

Best,

Sam