### PR TITLE
Unify the requirements of scikit-learn/sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sklearn>=0.0
+scikit-learn>=0.0
 pandas>=0.18.1
 numpy>=1.11.0
 pyomo>=5.3


### PR DESCRIPTION
Similar to requirements.yml the package scikit-learn should always be named as scikit-learn in the requirements.
Otherwise the installation will run the setup for the dummy-copy "sklearn", although the requirements for scikit-learn are already satisfied.
![grafik](https://user-images.githubusercontent.com/14281234/67471575-e832bf80-f64f-11e9-8b3f-c73b921413fb.png)

More information: https://stackoverflow.com/a/54573708
