### PR TITLE
Bump up the version to prevent deviation between pypi and Github version of pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(dir_path, "README.md"), "r") as fh:
 
 setuptools.setup(
     name="tsam",
-    version="2.3.4",
+    version="2.3.5",
     author="Leander Kotzur, Maximilian Hoffmann",
     author_email="leander.kotzur@googlemail.com, maximilian.hoffmann@julumni.fz-juelich.de",
     description="Time series aggregation module (tsam) to create typical periods",


### PR DESCRIPTION
The pypi 2.3.4 release on pypi contained a test that was not published on github and failed. This caused problems with the conda-forge release of tsam. The version is incremented because the same version cannot be released twice on pypi.