### PR TITLE
ci: force renovate to use chore(deps) prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
         "before 5am on monday"
     ],
     "timezone": "Europe/Berlin",
+    "commitMessagePrefix": "chore(deps):",
     "rangeStrategy": "widen",
     "enabledManagers": [
         "pep621",


### PR DESCRIPTION
## Summary
- Force all Renovate PRs to use `chore(deps):` prefix instead of the default `fix(deps):` for non-major updates
- This keeps dependency bumps hidden from the release changelog (since `chore` is a hidden type in our `changelog-sections` config)

## Test plan
- [ ] Verify next Renovate PR uses `chore(deps):` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)