### PR TITLE
fix: use column weights in tuning RMSE objective

### DIFF
--- a/src/tsam/tuning.py
+++ b/src/tsam/tuning.py
@@ -50,6 +50,23 @@ class _AggregateOpts(TypedDict):
 logger = logging.getLogger(__name__)
 
 
+def _compute_rmse(
+    result: AggregationResult,
+    weights: dict[str, float] | None,
+) -> float:
+    """Compute aggregate RMSE, optionally weighted by column weights.
+
+    When weights are provided, columns with higher weight contribute more
+    to the aggregate metric — matching the priority expressed by the user
+    during clustering.
+    """
+    per_col_rmse_sq = result.accuracy.rmse**2
+    if weights:
+        w = pd.Series(weights).reindex(per_col_rmse_sq.index, fill_value=1.0)
+        return float(np.sqrt((per_col_rmse_sq * w).sum() / w.sum()))
+    return float(np.sqrt(per_col_rmse_sq.mean()))
+
+
 def _test_single_config_file(
     args: dict,
 ) -> tuple[int, int, float, AggregationResult | None]:
@@ -96,7 +113,7 @@ def _test_single_config_file(
             round_decimals=opts["round_decimals"],
             numerical_tolerance=opts["numerical_tolerance"],
         )
-        rmse = float(np.sqrt((result.accuracy.rmse**2).mean()))
+        rmse = _compute_rmse(result, opts.get("weights"))
         return (n_clusters, n_segments, rmse, result)
     except Exception as e:
         logger.warning(
@@ -238,7 +255,7 @@ def _test_configs(
                     round_decimals=aggregate_opts["round_decimals"],
                     numerical_tolerance=aggregate_opts["numerical_tolerance"],
                 )
-                rmse = float(np.sqrt((result.accuracy.rmse**2).mean()))
+                rmse = _compute_rmse(result, aggregate_opts["weights"])
                 results.append((n_per, n_seg, rmse, result))
             except Exception as e:
                 logger.debug("Config (%d, %d) failed: %s", n_per, n_seg, e)


### PR DESCRIPTION
## Summary
- Tuning accepted `weights` but the RMSE used to rank configs was an unweighted `mean(rmse²)` across columns — the objective could contradict the user's stated priorities
- Added `_compute_rmse()` helper that uses a weighted mean when weights are provided
- Both parallel (`_test_single_config_file`) and sequential (`_test_configs`) paths now use the weighted metric
## Breaking:
- This will affect the "best_result" when using weights in tuning! As this is an edge case, and tuning is more used to explore, this is fine as a fix imo.
- Its definitely not a new feature. Users passing weights would expect the search to respect their weights, as the clustering does

## Test plan
- [x] All 496 existing tests pass
- [x] Verified weighted tuning picks different (correct) configs: unweighted → 219p×2s, solar-weighted → 146p×3s

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)