### PR TITLE
fix: make LegacyAPIWarning visible by default before v4 removal

### DIFF
--- a/src/tsam/exceptions.py
+++ b/src/tsam/exceptions.py
@@ -1,7 +1,7 @@
 """Custom exceptions and warnings for tsam."""
 
 
-class LegacyAPIWarning(DeprecationWarning):
+class LegacyAPIWarning(FutureWarning):
     """Warning for deprecated tsam legacy API usage.
 
     This warning is raised when using the old class-based API

--- a/src/tsam/hyperparametertuning.py
+++ b/src/tsam/hyperparametertuning.py
@@ -27,7 +27,8 @@ def getNoPeriodsForDataReduction(noRawTimeSteps, segmentsPerPeriod, dataReductio
         This function is deprecated along with the HyperTunedAggregations class.
     """
     warnings.warn(
-        "getNoPeriodsForDataReduction is deprecated along with HyperTunedAggregations.",
+        "getNoPeriodsForDataReduction will be removed in tsam v4.0. "
+        "Use tsam.tuning.find_optimal_combination() instead.",
         LegacyAPIWarning,
         stacklevel=2,
     )
@@ -53,7 +54,8 @@ def getNoSegmentsForDataReduction(noRawTimeSteps, typicalPeriods, dataReduction)
         This function is deprecated along with the HyperTunedAggregations class.
     """
     warnings.warn(
-        "getNoSegmentsForDataReduction is deprecated along with HyperTunedAggregations.",
+        "getNoSegmentsForDataReduction will be removed in tsam v4.0. "
+        "Use tsam.tuning.find_optimal_combination() instead.",
         LegacyAPIWarning,
         stacklevel=2,
     )
@@ -76,7 +78,7 @@ class HyperTunedAggregations:
             :func:`tsam.tuning.find_pareto_front` instead.
         """
         warnings.warn(
-            "HyperTunedAggregations is deprecated. "
+            "HyperTunedAggregations will be removed in tsam v4.0. "
             "Use tsam.tuning.find_optimal_combination() or tsam.tuning.find_pareto_front() instead.",
             LegacyAPIWarning,
             stacklevel=2,

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -44,7 +44,7 @@ def unstackToPeriods(timeSeries, timeStepsPerPeriod):
         Use :func:`tsam.unstack_to_periods` instead.
     """
     warnings.warn(
-        "unstackToPeriods is deprecated. Use tsam.unstack_to_periods() instead.",
+        "unstackToPeriods will be removed in tsam v4.0. Use tsam.unstack_to_periods() instead.",
         LegacyAPIWarning,
         stacklevel=2,
     )
@@ -289,7 +289,7 @@ class TimeSeriesAggregation:
         :type addMeanMax: list
         """
         warnings.warn(
-            "TimeSeriesAggregation is deprecated and will be removed in a future version. "
+            "TimeSeriesAggregation will be removed in tsam v4.0. "
             "Use tsam.aggregate() instead. See the migration guide in the documentation.",
             LegacyAPIWarning,
             stacklevel=2,


### PR DESCRIPTION
## Summary

- Change `LegacyAPIWarning` base class from `DeprecationWarning` to `FutureWarning`
- `DeprecationWarning` is silenced by default in Python (since 3.2) for library code — users calling tsam from their own modules never see the notice
- `FutureWarning` is always shown regardless of caller context
- All warning messages now explicitly mention removal in tsam v4.0

Closes #236

## Test plan

- [x] All existing tests pass
- [x] Warnings are now visible in library code (not just `__main__` / test runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)