### PR TITLE
fix: remove incorrect _SKIP_EQUIVALENCE for weighted configs

### DIFF
--- a/test/_old_new_equivalence.py
+++ b/test/_old_new_equivalence.py
@@ -448,15 +448,7 @@ _RTOL: dict[str, float] = {
     "kmeans_weighted_segmentation": 1e-5,
 }
 
-# Configs where old and new APIs intentionally diverge.
-# The new API applies weights only for clustering distance, not baked into
-# the normalized data. With medoid representation this can select a different
-# medoid, causing different typical periods, reconstruction, and accuracy.
-# Cluster *assignments* still match.
-_SKIP_EQUIVALENCE: set[str] = {
-    "hierarchical_weighted",
-    "hierarchical_weighted_segmentation",
-}
+_SKIP_EQUIVALENCE: set[str] = set()
 
 _WINDOWS_OPENMP_RUNTIME_WARNING_CASE_IDS = {
     "kmeans_distribution/testdata",


### PR DESCRIPTION
## Summary
- Remove `hierarchical_weighted` and `hierarchical_weighted_segmentation` from `_SKIP_EQUIVALENCE`
- The v4 pipeline bakes weights into candidates (step 2b), matching the old API's behavior — these configs are no longer expected to diverge
- The old comment ("new API applies weights only for clustering distance, not baked into normalized data") was incorrect for the v4 pipeline

## Test plan
- [x] All 60 weighted equivalence tests pass (were previously skipped)
- [x] 499 other tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)