### PR TITLE
feat: preserve DatetimeIndex through aggregate/disaggregate round-trip

### DIFF
--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -381,6 +381,7 @@ def aggregate(
     )
 
     # Build ClusteringResult
+    time_index = data.index if isinstance(data.index, pd.DatetimeIndex) else None
     clustering_result = _build_clustering_result(
         agg=agg,
         n_segments=segments.n_segments if segments else None,
@@ -391,6 +392,7 @@ def aggregate(
         preserve_column_means=preserve_column_means,
         rescale_exclude_columns=rescale_exclude_columns,
         temporal_resolution=temporal_resolution,
+        time_index=time_index,
     )
 
     # Compute segment_durations as tuple of tuples
@@ -431,6 +433,7 @@ def _build_clustering_result(
     preserve_column_means: bool = True,
     rescale_exclude_columns: list[str] | None = None,
     temporal_resolution: float | None = None,
+    time_index: pd.DatetimeIndex | None = None,
 ) -> ClusteringResult:
     """Build ClusteringResult from a TimeSeriesAggregation object."""
     # Get cluster centers (convert to Python ints for JSON serialization)
@@ -520,6 +523,7 @@ def _build_clustering_result(
         cluster_config=cluster_config,
         segment_config=segment_config,
         extremes_config=extremes_config,
+        time_index=time_index,
     )
 
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -576,6 +576,9 @@ class ClusteringResult:
     extreme_cluster_indices: tuple[int, ...] | None = None
     weights: dict[str, float] | None = None
 
+    # === Index fields (for disaggregate() round-trip) ===
+    time_index: pd.DatetimeIndex | None = None
+
     # === Reference fields (for documentation, not used by apply()) ===
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
@@ -715,6 +718,16 @@ class ClusteringResult:
             result["extreme_cluster_indices"] = list(self.extreme_cluster_indices)
         if self.weights is not None:
             result["weights"] = self.weights
+        if self.time_index is not None:
+            freq = pd.infer_freq(self.time_index)
+            if freq is not None:
+                result["time_index"] = {
+                    "start": self.time_index[0].isoformat(),
+                    "periods": len(self.time_index),
+                    "freq": freq,
+                }
+            else:
+                result["time_index"] = [t.isoformat() for t in self.time_index]
         # Reference fields (optional, for documentation)
         if self.cluster_config is not None:
             result["cluster_config"] = self.cluster_config.to_dict()
@@ -759,6 +772,15 @@ class ClusteringResult:
             kwargs["extreme_cluster_indices"] = tuple(data["extreme_cluster_indices"])
         if "weights" in data:
             kwargs["weights"] = data["weights"]
+        raw_time_index = data.get("time_index")
+        if isinstance(raw_time_index, dict):
+            kwargs["time_index"] = pd.date_range(
+                raw_time_index["start"],
+                periods=raw_time_index["periods"],
+                freq=raw_time_index["freq"],
+            )
+        elif isinstance(raw_time_index, list):
+            kwargs["time_index"] = pd.DatetimeIndex(raw_time_index)
         # Reference fields
         if "cluster_config" in data:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
@@ -890,7 +912,12 @@ class ClusteringResult:
         if is_segmented_input:
             data = _expand_segments_to_timesteps(data, self.segment_durations)  # type: ignore[arg-type]
 
-        return _expand_periods(data, self.cluster_assignments)
+        result = _expand_periods(data, self.cluster_assignments)
+
+        if self.time_index is not None and len(self.time_index) == len(result):
+            result.index = self.time_index
+
+        return result
 
     def apply(
         self,
@@ -1094,6 +1121,9 @@ class ClusteringResult:
         # Build ClusteringResult - preserve stored values
         from tsam.api import _build_clustering_result
 
+        apply_time_index = (
+            data.index if isinstance(data.index, pd.DatetimeIndex) else None
+        )
         clustering_result = _build_clustering_result(
             agg=agg,
             n_segments=n_segments,
@@ -1106,6 +1136,7 @@ class ClusteringResult:
             if self.rescale_exclude_columns
             else None,
             temporal_resolution=effective_temporal_resolution,
+            time_index=apply_time_index,
         )
 
         # Build result object

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -153,6 +153,27 @@ def _representation_from_dict(data: str | dict) -> Representation:
     raise ValueError(f"Unknown representation type: {rep_type!r}")
 
 
+def _time_index_to_dict(idx: pd.DatetimeIndex) -> dict[str, Any] | list[str]:
+    """Serialize a DatetimeIndex compactly when possible.
+
+    Regular indices are stored as ``{start, periods, freq}`` (~3 values).
+    Irregular indices fall back to a full ISO string list.
+    """
+    freq = pd.infer_freq(idx)
+    if freq is not None:
+        return {"start": idx[0].isoformat(), "periods": len(idx), "freq": freq}
+    return [t.isoformat() for t in idx]
+
+
+def _time_index_from_dict(
+    raw: dict[str, Any] | list[str],
+) -> pd.DatetimeIndex:
+    """Deserialize a DatetimeIndex from either compact or list format."""
+    if isinstance(raw, dict):
+        return pd.date_range(raw["start"], periods=raw["periods"], freq=raw["freq"])
+    return pd.DatetimeIndex(raw)
+
+
 @dataclass(frozen=True)
 class ClusterConfig:
     """Configuration for the clustering algorithm.
@@ -719,15 +740,7 @@ class ClusteringResult:
         if self.weights is not None:
             result["weights"] = self.weights
         if self.time_index is not None:
-            freq = pd.infer_freq(self.time_index)
-            if freq is not None:
-                result["time_index"] = {
-                    "start": self.time_index[0].isoformat(),
-                    "periods": len(self.time_index),
-                    "freq": freq,
-                }
-            else:
-                result["time_index"] = [t.isoformat() for t in self.time_index]
+            result["time_index"] = _time_index_to_dict(self.time_index)
         # Reference fields (optional, for documentation)
         if self.cluster_config is not None:
             result["cluster_config"] = self.cluster_config.to_dict()
@@ -773,14 +786,8 @@ class ClusteringResult:
         if "weights" in data:
             kwargs["weights"] = data["weights"]
         raw_time_index = data.get("time_index")
-        if isinstance(raw_time_index, dict):
-            kwargs["time_index"] = pd.date_range(
-                raw_time_index["start"],
-                periods=raw_time_index["periods"],
-                freq=raw_time_index["freq"],
-            )
-        elif isinstance(raw_time_index, list):
-            kwargs["time_index"] = pd.DatetimeIndex(raw_time_index)
+        if raw_time_index is not None:
+            kwargs["time_index"] = _time_index_from_dict(raw_time_index)
         # Reference fields
         if "cluster_config" in data:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -225,6 +225,42 @@ class TestClusteringResultDisaggregate:
         np.testing.assert_array_equal(original.values[mask], restored.values[mask])
 
 
+class TestTimeIndexSerialization:
+    """Unit tests for _time_index_to_dict / _time_index_from_dict helpers."""
+
+    def test_regular_index_compact(self):
+        from tsam.config import _time_index_to_dict
+
+        idx = pd.date_range("2025-01-01", periods=8760, freq="h")
+        d = _time_index_to_dict(idx)
+        assert isinstance(d, dict)
+        assert set(d) == {"start", "periods", "freq"}
+        assert d["periods"] == 8760
+
+    def test_regular_index_roundtrip(self):
+        from tsam.config import _time_index_from_dict, _time_index_to_dict
+
+        idx = pd.date_range("2025-01-01", periods=8760, freq="h")
+        restored = _time_index_from_dict(_time_index_to_dict(idx))
+        pd.testing.assert_index_equal(idx, restored)
+
+    def test_irregular_index_fallback(self):
+        from tsam.config import _time_index_from_dict, _time_index_to_dict
+
+        idx = pd.DatetimeIndex(["2025-01-01", "2025-01-03", "2025-01-07"])
+        d = _time_index_to_dict(idx)
+        assert isinstance(d, list)
+        restored = _time_index_from_dict(d)
+        pd.testing.assert_index_equal(idx, restored)
+
+    def test_old_list_format_still_loads(self):
+        from tsam.config import _time_index_from_dict
+
+        raw = ["2025-01-01T00:00:00", "2025-01-01T01:00:00"]
+        restored = _time_index_from_dict(raw)
+        assert len(restored) == 2
+
+
 class TestDisaggregateEdgeCases:
     """Edge cases and robustness tests."""
 

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -105,8 +105,20 @@ class TestAggregationResultDisaggregate:
 class TestClusteringResultDisaggregate:
     """Tests for ClusteringResult.disaggregate."""
 
-    def test_integer_index(self, result):
+    def test_datetime_index_restored(self, result):
         expanded = result.clustering.disaggregate(result.cluster_representatives)
+        if result.clustering.time_index is not None:
+            assert isinstance(expanded.index, pd.DatetimeIndex)
+            assert expanded.index.equals(result.clustering.time_index)
+        else:
+            assert isinstance(expanded.index, pd.RangeIndex)
+
+    def test_integer_index_when_no_time_index(self, result):
+        """Without time_index, disaggregate returns a RangeIndex."""
+        from dataclasses import replace
+
+        clustering_no_ti = replace(result.clustering, time_index=None)
+        expanded = clustering_no_ti.disaggregate(result.cluster_representatives)
         assert isinstance(expanded.index, pd.RangeIndex)
 
     def test_shape(self, result):
@@ -169,6 +181,32 @@ class TestClusteringResultDisaggregate:
         original = result.clustering.disaggregate(result.cluster_representatives)
         restored = loaded.disaggregate(result.cluster_representatives)
         np.testing.assert_array_equal(original.values, restored.values)
+
+    def test_io_roundtrip_preserves_time_index(self, result, tmp_path):
+        """JSON round-trip preserves the original DatetimeIndex."""
+        path = tmp_path / "clustering.json"
+        result.clustering.to_json(str(path))
+        loaded = ClusteringResult.from_json(str(path))
+
+        assert loaded.time_index is not None
+        assert loaded.time_index.equals(result.clustering.time_index)
+
+        restored = loaded.disaggregate(result.cluster_representatives)
+        assert isinstance(restored.index, pd.DatetimeIndex)
+        assert restored.index.equals(result.clustering.time_index)
+
+    def test_io_roundtrip_no_time_index(self, tmp_path):
+        """Old serialized files without time_index still work."""
+
+        cr = ClusteringResult(
+            period_duration=24.0,
+            cluster_assignments=(0, 1, 0, 1),
+            n_timesteps_per_period=24,
+        )
+        path = tmp_path / "clustering.json"
+        cr.to_json(str(path))
+        loaded = ClusteringResult.from_json(str(path))
+        assert loaded.time_index is None
 
     def test_io_roundtrip_segmented(self, result_segmented, tmp_path):
         path = tmp_path / "clustering.json"


### PR DESCRIPTION
## Summary
- Adds `time_index` field to `ClusteringResult` that stores the original `DatetimeIndex` from `aggregate()` input data
- `disaggregate()` restores the time index on the output DataFrame when available
- `to_dict()`/`from_dict()` serialize the index compactly (`{start, periods, freq}` for regular indices, ISO list fallback for irregular ones)
- Fully backward-compatible: `time_index` defaults to `None`, old serialized files work unchanged

Closes https://github.com/FZJ-IEK3-VSA/tsam/issues/266

## Test plan
- [x] New test: `test_datetime_index_restored` — disaggregate returns DatetimeIndex matching original
- [x] New test: `test_integer_index_when_no_time_index` — RangeIndex when no time_index stored
- [x] New test: `test_io_roundtrip_preserves_time_index` — JSON round-trip preserves DatetimeIndex
- [x] New test: `test_io_roundtrip_no_time_index` — backward compat with old files
- [x] All 477 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)