### PR TITLE
fix: KeyError in accuracyIndicators() when weightDict is a column subset

### DIFF
--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -1444,7 +1444,9 @@ class TimeSeriesAggregation:
 
         for column in self.normalizedTimeSeries.columns:
             if self.weightDict:
-                origTS = self.normalizedTimeSeries[column] / self.weightDict[column]
+                origTS = self.normalizedTimeSeries[column] / self.weightDict.get(
+                    column, 1
+                )
             else:
                 origTS = self.normalizedTimeSeries[column]
             predTS = self.normalizedPredictedData[column]

--- a/test/test_clustering_e2e.py
+++ b/test/test_clustering_e2e.py
@@ -438,6 +438,19 @@ class TestClusteringTransfer:
             input_data.columns
         )
 
+    def test_apply_with_weights_and_extra_columns(self, input_data):
+        """Test applying clustering when data has columns not in weights (GH-276)."""
+        # Cluster on a single column with explicit weights
+        wind_only = input_data[["Wind"]]
+        result_wind = aggregate(wind_only, n_clusters=8, weights={"Wind": 1.0})
+
+        # Apply to full data (has extra columns not in weights) - should not raise
+        result_full = result_wind.clustering.apply(input_data)
+
+        # Accuracy metrics should cover all columns in the applied data
+        assert result_full.accuracy is not None
+        assert len(result_full.accuracy.rmse) == len(input_data.columns)
+
     def test_segmentation_preserved_in_transfer(self, input_data, tmp_path):
         """Test that segmentation info is preserved through JSON roundtrip."""
         from tsam import ClusteringResult


### PR DESCRIPTION
## Summary
- `accuracyIndicators()` raised `KeyError` when `weightDict` didn't contain all columns in the data (e.g. when `apply()` is used with extra columns)
- Use `.get(column, 1)` instead of `[column]` so unweighted columns default to weight 1
- Added regression test

Closes #276

## Test plan
- [x] Reproducer from issue no longer raises `KeyError`
- [x] New test `test_apply_with_weights_and_extra_columns` passes
- [x] All existing tests pass (481 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)