### PR TITLE
fix: handle missing columns in weightDict in accuracyIndicators

### DIFF
--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -1443,10 +1443,8 @@ class TimeSeriesAggregation:
         }  # 'Silhouette score':{},
 
         for column in self.normalizedTimeSeries.columns:
-            if self.weightDict:
-                origTS = self.normalizedTimeSeries[column] / self.weightDict[column]
-            else:
-                origTS = self.normalizedTimeSeries[column]
+            weight = self.weightDict.get(column, 1.0) if self.weightDict else 1.0
+            origTS = self.normalizedTimeSeries[column] / weight
             predTS = self.normalizedPredictedData[column]
             indicatorRaw["RMSE"][column] = np.sqrt(mean_squared_error(origTS, predTS))
             indicatorRaw["RMSE_duration"][column] = np.sqrt(

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -1448,6 +1448,7 @@ class TimeSeriesAggregation:
                     column, 1
                 )
             else:
+                origTS = self.normalizedTimeSeries[column]
 
             predTS = self.normalizedPredictedData[column]
             indicatorRaw["RMSE"][column] = np.sqrt(mean_squared_error(origTS, predTS))

--- a/test/test_accuracyIndicators.py
+++ b/test/test_accuracyIndicators.py
@@ -72,4 +72,3 @@ def test_accuracyIndicators_partial_weights():
 
     indicators = aggregation.accuracyIndicators()
     assert set(indicators.index) == set(raw.columns)
-

--- a/test/test_accuracyIndicators.py
+++ b/test/test_accuracyIndicators.py
@@ -73,7 +73,3 @@ def test_accuracyIndicators_partial_weights():
     indicators = aggregation.accuracyIndicators()
     assert set(indicators.index) == set(raw.columns)
 
-
-if __name__ == "__main__":
-    test_accuracyIndicators()
-    test_accuracyIndicators_partial_weights()

--- a/test/test_accuracyIndicators.py
+++ b/test/test_accuracyIndicators.py
@@ -53,5 +53,27 @@ def test_accuracyIndicators():
     )
 
 
+def test_accuracyIndicators_partial_weights():
+    # Regression: GH #276. accuracyIndicators raised KeyError when the data
+    # had columns absent from weightDict.
+    hoursPerPeriod = 24
+    noTypicalPeriods = 8
+    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+    partial_weights = {raw.columns[0]: 2.0}
+
+    aggregation = tsam.TimeSeriesAggregation(
+        raw,
+        noTypicalPeriods=noTypicalPeriods,
+        hoursPerPeriod=hoursPerPeriod,
+        clusterMethod="hierarchical",
+        weightDict=partial_weights,
+    )
+
+    indicators = aggregation.accuracyIndicators()
+    assert set(indicators.index) == set(raw.columns)
+
+
 if __name__ == "__main__":
     test_accuracyIndicators()
+    test_accuracyIndicators_partial_weights()


### PR DESCRIPTION
Fixes #276.

`accuracyIndicators()` raised `KeyError` when iterating over `normalizedTimeSeries.columns` if `weightDict` was provided but did not cover every column. This affects `ClusteringResult.apply()` whenever new data has columns absent from the original clustering's `weights`.

Fallback to unit weight for missing columns, matching the behavior when `weightDict` is empty. Added regression test `test_accuracyIndicators_partial_weights`.