### PR TITLE
chore: migrate from mypy to ty for static type checking

### DIFF
--- a/.github/workflows/ci-develop.yaml
+++ b/.github/workflows/ci-develop.yaml
@@ -112,10 +112,26 @@ jobs:
       - name: Build MkDocs
         run: mkdocs build --strict
 
+  type-check:
+    name: Type check (ty)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: uv pip install --system ".[develop]"
+      - name: Run ty
+        run: ty check src/tsam/
+
   ci-success:
     name: CI Success
     if: always()
-    needs: [pre-commit, test, docs]
+    needs: [pre-commit, test, docs, type-check]
     runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -131,10 +131,27 @@ jobs:
       - name: Build MkDocs
         run: mkdocs build --strict
 
+  type-check:
+    name: Type check (ty)
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: uv pip install --system ".[develop]"
+      - name: Run ty
+        run: ty check src/tsam/
+
   ci-success:
     name: CI Success
     if: ${{ always() && !startsWith(github.head_ref, 'release-please--') }}
-    needs: [pre-commit, test, docs]
+    needs: [pre-commit, test, docs, type-check]
     runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,3 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
-    hooks:
-      - id: mypy
-        additional_dependencies:
-          - pandas-stubs
-        args: [--ignore-missing-imports]
-        exclude: ^(docs/|test/|benchmarks/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -86,12 +86,12 @@ ruff check src/ test/ --fix
 ruff format src/ test/
 ```
 
-**Type Checking with Mypy**
+**Type Checking with ty**
 
-[Mypy](https://mypy.readthedocs.io/) is used for static type checking:
+[ty](https://github.com/astral-sh/ty) is used for static type checking:
 
 ```bash
-mypy src/tsam/
+ty check src/tsam/
 ```
 
 **Pre-commit Hooks**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ develop = [
   "mkdocs-literate-nav>=0.6,<=0.6.3",
   "nbval<=0.11.0",
   "ruff<=0.15.12",
-  "mypy<=1.20.2",
+  "ty<=0.0.35",
   "pandas-stubs<=3.0.0.260204",
   "pre-commit<=4.5.1",
   "plotly>=5.0.0,<=6.7.0",
@@ -138,13 +138,11 @@ known-first-party = ["tsam"]
   "TCH002",
 ] # pandas/numpy needed at runtime for dataclass fields
 
-[tool.mypy]
-python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-ignore_missing_imports = true
-exclude = ["docs/", "build/"]
+[tool.ty.src]
+exclude = ["docs/", "test/", "benchmarks/", "build/"]
 
-[[tool.mypy.overrides]]
-module = "tsam.*"
-ignore_missing_imports = true
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.rules]
+unresolved-import = "ignore"

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -367,7 +367,7 @@ def aggregate(
         rescale_deviations.index.name = "column"
     else:
         rescale_deviations = pd.DataFrame(
-            columns=["deviation_pct", "converged", "iterations"]
+            columns=pd.Index(["deviation_pct", "converged", "iterations"])
         )
 
     accuracy = AccuracyMetrics(

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -143,7 +143,7 @@ def _representation_to_dict(rep: Representation) -> str | dict[str, Any]:
 def _representation_from_dict(data: str | dict) -> Representation:
     """Deserialize a representation value from a JSON-compatible format."""
     if isinstance(data, str):
-        return data  # type: ignore[return-value]
+        return cast("RepresentationMethod", data)
     # It's a dict with a "type" key
     rep_type = data.get("type")
     if rep_type == "distribution":
@@ -917,7 +917,8 @@ class ClusteringResult:
         data = _validate_disaggregate_input(data, self, is_segmented=is_segmented_input)
 
         if is_segmented_input:
-            data = _expand_segments_to_timesteps(data, self.segment_durations)  # type: ignore[arg-type]
+            assert self.segment_durations is not None
+            data = _expand_segments_to_timesteps(data, self.segment_durations)
 
         result = _expand_periods(data, self.cluster_assignments)
 
@@ -1108,7 +1109,7 @@ class ClusteringResult:
             rescale_deviations.index.name = "column"
         else:
             rescale_deviations = pd.DataFrame(
-                columns=["deviation_pct", "converged", "iterations"]
+                columns=pd.Index(["deviation_pct", "converged", "iterations"])
             )
 
         from tsam.api import _weighted_mean, _weighted_rms

--- a/src/tsam/periodAggregation.py
+++ b/src/tsam/periodAggregation.py
@@ -58,7 +58,7 @@ def aggregatePeriods(
             clusterOrder.append(
                 [n_clusters - 1] * int(n_sets - cluster_size * n_clusters)
             )
-        clusterOrder = np.hstack(np.array(clusterOrder, dtype=object))
+        clusterOrder = np.hstack(clusterOrder)
         clusterCenters, clusterCenterIndices = representations(
             repr_candidates,
             clusterOrder,

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -721,6 +721,11 @@ class TimeSeriesAggregation:
         self.extremePeriods = {}
         extremePeriodNo = []
 
+        addPeakMax = addPeakMax or []
+        addPeakMin = addPeakMin or []
+        addMeanMax = addMeanMax or []
+        addMeanMin = addMeanMin or []
+
         ccList = [center.tolist() for center in clusterCenters]
 
         # check which extreme periods exist in the profile and add them to
@@ -881,7 +886,7 @@ class TimeSeriesAggregation:
             return column + append_with
         elif isinstance(column, tuple):
             col = list(column)
-            col[-1] = col[-1] + append_with
+            col[-1] = str(col[-1]) + append_with
             return tuple(col)
 
     def _rescaleClusterPeriods(self, clusterOrder, clusterPeriods, extremeClusterIdx):
@@ -1399,7 +1404,7 @@ class TimeSeriesAggregation:
         # create a dataframe
         timeStepMatching = pd.DataFrame(
             [periodIndex, stepIndex],
-            index=["PeriodNum", "TimeStep"],
+            index=pd.Index(["PeriodNum", "TimeStep"]),
             columns=self.timeIndex,
         ).T
 
@@ -1415,11 +1420,11 @@ class TimeSeriesAggregation:
                         self.segmentedNormalizedTypicalPeriods.loc[
                             label, :
                         ].index.get_level_values(1),
-                    ).values
+                    ).values  # ty: ignore[unresolved-attribute]
                 )
             timeStepMatching = pd.DataFrame(
                 [periodIndex, stepIndex, segmentIndex],
-                index=["PeriodNum", "TimeStep", "SegmentIndex"],
+                index=pd.Index(["PeriodNum", "TimeStep", "SegmentIndex"]),
                 columns=self.timeIndex,
             ).T
 

--- a/src/tsam/utils/durationRepresentation.py
+++ b/src/tsam/utils/durationRepresentation.py
@@ -1,6 +1,7 @@
 """Orders a set of representation values to fit several candidate value sets"""
 
 import warnings
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -81,7 +82,7 @@ def durationRepresentation(
 
     else:
         clusterCentersList = []
-        for a in candidates_df.columns.levels[0]:
+        for a in cast("pd.MultiIndex", candidates_df.columns).levels[0]:
             meanVals = []
             clusterLengths = []
             for clusterNum in np.unique(clusterOrder):

--- a/src/tsam/utils/k_maxoids.py
+++ b/src/tsam/utils/k_maxoids.py
@@ -1,10 +1,17 @@
 """Exact K-maxoids clustering"""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import numpy.random as rnd
 from sklearn.base import BaseEstimator, ClusterMixin, TransformerMixin
 from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from sklearn.utils import check_array
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
@@ -26,6 +33,8 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
         self.n_clusters = n_clusters
 
         self.distance_metric = distance_metric
+
+        self.distance_func: Callable | None = None
 
     def _check_init_args(self):
         # Check n_clusters
@@ -67,6 +76,7 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
         X = self._check_array(X)
 
         # apply distance metric to get the distance matrix (kept for potential debugging)
+        assert self.distance_func is not None
         _D = self.distance_func(X)
 
         # run mk-maxoids clustering
@@ -90,6 +100,7 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
         return X
 
     def k_maxoids(self, X, k, numpasses=5, doLogarithmic=False, n_init=100):
+        assert self.distance_func is not None
         X_old = X
         n, _m = X.shape
         inertiaTempPrime = None

--- a/src/tsam/utils/k_medoids_contiguity.py
+++ b/src/tsam/utils/k_medoids_contiguity.py
@@ -3,8 +3,8 @@ import time
 import numpy as np
 
 # switch to numpy 2.0 (restore deprecated aliases for backward compatibility)
-np.float_ = np.float64  # type: ignore[attr-defined]
-np.complex_ = np.complex128  # type: ignore[attr-defined]
+np.float_ = np.float64  # ty: ignore[unresolved-attribute]
+np.complex_ = np.complex128  # ty: ignore[unresolved-attribute]
 
 import networkx as nx
 import pyomo.environ as pyomo

--- a/src/tsam/utils/k_medoids_exact.py
+++ b/src/tsam/utils/k_medoids_exact.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClusterMixin, TransformerMixin
 from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from sklearn.utils import check_array
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 # switch to numpy 2.0 (restore deprecated aliases for backward compatibility)
-np.float_ = np.float64  # type: ignore[attr-defined]
-np.complex_ = np.complex128  # type: ignore[attr-defined]
+np.float_ = np.float64  # ty: ignore[unresolved-attribute]
+np.complex_ = np.complex128  # ty: ignore[unresolved-attribute]
 
 import pyomo.environ as pyomo
 import pyomo.opt as opt
@@ -50,6 +57,8 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
 
         self.threads = threads
 
+        self.distance_func: Callable | None = None
+
     def _check_init_args(self):
         # Check n_clusters
         if (
@@ -90,6 +99,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         X = self._check_array(X)
 
         # apply distance metric to get the distance matrix
+        assert self.distance_func is not None
         D = self.distance_func(X)
 
         # run exact optimization

--- a/src/tsam/utils/segmentation.py
+++ b/src/tsam/utils/segmentation.py
@@ -119,7 +119,8 @@ def segmentation(
             # Use predefined segment order
             clusterOrder = np.asarray(predefSegmentOrder[period_i])
 
-            # Get predefined durations
+            # Get predefined durations (validated non-None alongside predefSegmentOrder above)
+            assert predefSegmentDurations is not None
             segmentNoOccur = np.asarray(predefSegmentDurations[period_i])
 
             # Calculate segment numbers and start indices from durations
@@ -201,7 +202,7 @@ def segmentation(
         )
         # keep additional information on the lengths of the segments in the right order
         segmentDuration = (
-            pd.DataFrame(segmentNoOccur, columns=["Segment Duration"])
+            pd.DataFrame(segmentNoOccur, columns=pd.Index(["Segment Duration"]))
             .reindex(clusterOrderUnique)
             .set_index(np.sort(indices))
         )


### PR DESCRIPTION
## Summary
Stacked on top of #289. Swaps mypy for [ty](https://github.com/astral-sh/ty) (Astral's new type checker) and fixes all 28 diagnostics it surfaces (mypy reported 2).

- Drop mypy pre-commit hook (ty needs the real project venv, not pre-commit's isolated env).
- Add a dedicated `type-check` CI job in both workflows that installs `.[develop]` and runs `ty check src/tsam/`.
- Replace `mypy` with `ty<=0.0.35` in develop extras; swap `[tool.mypy]` for `[tool.ty.*]` in `pyproject.toml`.
- Fix 28 diagnostics across 9 files (callable narrowing, None-safety, pandas-stubs workarounds). All 482 tests pass.

Context: #287 discussion.

## ⚠️ Required after merge
If branch protection requires a `Type check` status, add it. Update any other status-check requirements for develop/master accordingly.

## Notes
- Rebase onto `develop` once #289 merges and re-target base.
- ty is alpha (currently 0.0.35); pinned with upper bound so future changes don't surprise CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)