### PR TITLE
ci: add workflow_dispatch for pre-commit auto-fix PRs

### DIFF
--- a/.github/workflows/pre-commit-autofix.yaml
+++ b/.github/workflows/pre-commit-autofix.yaml
@@ -1,0 +1,49 @@
+name: Pre-commit autofix PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Branch to run pre-commit against and open the PR back into"
+        required: true
+        default: "develop"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autofix:
+    name: Run pre-commit and open PR
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run pre-commit (allow modifications)
+        uses: pre-commit/action@v3.0.1
+        continue-on-error: true
+
+      - name: Open PR with auto-fixes (if any)
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ inputs.target_branch }}
+          branch: pre-commit-autofix/${{ inputs.target_branch }}
+          delete-branch: true
+          commit-message: "style: apply pre-commit auto-fixes"
+          title: "style: apply pre-commit auto-fixes to ${{ inputs.target_branch }}"
+          body: |
+            Automated pre-commit auto-fixes for `${{ inputs.target_branch }}`,
+            triggered via `workflow_dispatch` by @${{ github.actor }}.
+
+            If the diff looks correct, merge to apply the fixes. If nothing
+            needed fixing, this PR will not be opened.
+          labels: |
+            automated
+            pre-commit


### PR DESCRIPTION
## Summary

Adds a manually-triggered GitHub Actions workflow that runs pre-commit against any branch and opens a PR with the auto-fixes.

- Trigger from **Actions → Pre-commit autofix PR → Run workflow**, pick a branch from the dropdown.
- Runs `pre-commit/action@v3.0.1` with `continue-on-error: true` so hook modifications don't fail the job.
- Uses `peter-evans/create-pull-request@v7` to open a PR against the chosen branch on the `pre-commit-autofix/<branch>` head. No PR is opened if pre-commit had nothing to fix.

## Why

`pre-commit.ci`'s `autofix_prs` only fixes branches that already have an open PR. This complements that by letting maintainers run pre-commit on arbitrary branches — long-lived feature branches, release branches, or stale branches that need a tidy-up before a PR is opened.

## Test plan

- [ ] Merge, then trigger the workflow from the Actions tab with `develop` selected — should open no PR (develop is already clean).
- [ ] Trigger it against a branch with known whitespace issues — should open a `pre-commit-autofix/<branch>` PR with the auto-fixes.
- [ ] Verify `delete-branch: true` removes the head branch after the PR is closed/merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)