### PR TITLE
ci: replace renovate regex lookahead with re2-compatible separator

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,12 +41,12 @@
         },
         {
             "customType": "regex",
-            "description": "Match deps in pyproject.toml that are also pinned in environment.yml; resolve via conda-forge so PRs only open once a release is on both channels. IMPORTANT: this list of package names must mirror the matchPackageNames list in the pep621-disable packageRule below — both are derived from the deps shared between pyproject.toml and environment.yml. The `(?![a-zA-Z0-9_-])` lookahead after depName prevents prefix-matching against longer package names that are NOT in the alternation (e.g. pytest-benchmark, mkdocstrings, pandas-stubs — PyPI-only deps handled by the pep621 manager). Longer names that ARE in the alternation must still precede their prefixes (e.g. pytest-cov before pytest) so left-to-right alternation picks them first.",
+            "description": "Match deps in pyproject.toml that are also pinned in environment.yml; resolve via conda-forge so PRs only open once a release is on both channels. IMPORTANT: this list of package names must mirror the matchPackageNames list in the pep621-disable packageRule below — both are derived from the deps shared between pyproject.toml and environment.yml. The optional `(?:[<>=,\"][^\"]*?)?` group after depName forces a constraint separator (`<`, `>`, `=`, `,`, or the closing quote) to follow, preventing prefix-matches against longer package names that are NOT in the alternation (e.g. pytest-benchmark, mkdocstrings, pandas-stubs — PyPI-only deps handled by the pep621 manager). Lookaheads can't be used here because Renovate's regex engine (re2) rejects them with `invalid perl operator: (?!`. Longer names that ARE in the alternation must still precede their prefixes (e.g. pytest-cov before pytest) so left-to-right alternation picks them first.",
             "managerFilePatterns": [
                 "/(^|/)pyproject\\.toml$/"
             ],
             "matchStrings": [
-                "\"(?<depName>scikit-learn|mkdocs-literate-nav|mkdocs-gen-files|mkdocs-jupyter|mkdocs-material|pytest-xdist|pytest-cov|pre-commit|networkx|highspy|codecov|plotly|mkdocs|pytest|pyomo|pandas|numpy|nbval|ruff|mypy|tqdm)(?![a-zA-Z0-9_-])[^\"]*?(?<currentValue><=?\\d[^\",]*)"
+                "\"(?<depName>scikit-learn|mkdocs-literate-nav|mkdocs-gen-files|mkdocs-jupyter|mkdocs-material|pytest-xdist|pytest-cov|pre-commit|networkx|highspy|codecov|plotly|mkdocs|pytest|pyomo|pandas|numpy|nbval|ruff|mypy|tqdm)(?:[<>=,\"][^\"]*?)?(?<currentValue><=?\\d[^\",]*)"
             ],
             "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",


### PR DESCRIPTION
## Summary

- The merged fix in #295 used a negative lookahead `(?![a-zA-Z0-9_-])` after `depName` in the custom regex manager. Renovate's regex engine (re2) **does not support lookaheads** — it rejects them at config-validation time with `invalid perl operator: (?!` ([log evidence](https://github.com/FZJ-IEK3-VSA/tsam/issues/296)).
- Effect on `develop`: Renovate fails to load the config entirely. Issue #296 was raised, and #169 still shows the bogus `pytest <=5.4.3` / `pytest v9` suggestions because Renovate is operating on stale cached data from before the broken config landed.
- Fix: replace the lookahead with an optional non-capturing group `(?:[<>=,"][^"]*?)?` after `depName`. This forces a constraint separator (`<`, `>`, `=`, `,`, or the closing quote) to follow a real dep, which blocks the alternation from prefix-matching PyPI-only deps (handled by the `pep621` manager). Equivalent semantics, no lookahead.

## Test plan

- [x] Installed the `re2` npm package locally and confirmed:
  - The previous lookahead pattern: `REJECTED — invalid perl operator: (?!`
  - The new pattern: accepted and produces the correct match/no-match for every dep in `pyproject.toml` (false positives `pytest-benchmark`, `mkdocstrings`, `pandas-stubs` → no match; all real deps → correct `depName` + `currentValue`).
- [ ] After merge: confirm #296 auto-closes when Renovate next runs against `develop`, and the `pytest <=5.4.3` / `pytest v9` / `mkdocs <=1.6.1` entries disappear from #169.

Closes #296