### PR TITLE
test: port partial-weights regression test for accuracy_indicators

### DIFF
--- a/test/test_accuracyIndicators.py
+++ b/test/test_accuracyIndicators.py
@@ -53,5 +53,26 @@ def test_accuracyIndicators():
     )
 
 
+def test_accuracy_indicators_partial_weights():
+    # Regression: GH #276. accuracy_indicators raised KeyError when the data
+    # had columns absent from weight_dict.
+    hours_per_period = 24
+    no_typical_periods = 8
+    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+    partial_weights = {raw.columns[0]: 2.0}
+
+    aggregation = tsam.TimeSeriesAggregation(
+        raw,
+        no_typical_periods=no_typical_periods,
+        hours_per_period=hours_per_period,
+        cluster_method="hierarchical",
+        weight_dict=partial_weights,
+    )
+
+    indicators = aggregation.accuracy_indicators()
+    assert set(indicators.index) == set(raw.columns)
+
+
 if __name__ == "__main__":
     test_accuracyIndicators()


### PR DESCRIPTION
## Summary
- Adds `test_accuracy_indicators_partial_weights` from develop (#277 / #288) so v4 has the same regression coverage.
- No production code change. v4's `_weighted_rms` / `_weighted_mean` in `src/tsam/api.py` already handle missing `weight_dict` keys via `pd.Series(weights).reindex(fill_value=1.0)`, so the underlying KeyError cannot occur here. This PR just locks that guarantee in place.

## Test plan
- [x] `pytest test/test_accuracyIndicators.py` — 2 passed.

Closes #312.