### PR TITLE
feat: preserve DatetimeIndex through aggregate/disaggregate round-trip

### DIFF
--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -378,7 +378,6 @@ def _build_aggregation_result(
         is_transferred=is_transferred,
         _original_data=result.original_data,
         _reconstructed_data=result.reconstructed_data,
-        _time_index=result.time_index,
         _norm_values=result._norm_values,
         _normalized_predicted=result._normalized_predicted,
         _rescale_deviations=rescale_deviations,

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -142,6 +142,27 @@ def _representation_from_dict(data: str | dict) -> Representation:
     raise ValueError(f"Unknown representation type: {rep_type!r}")
 
 
+def _time_index_to_dict(idx: pd.DatetimeIndex) -> dict[str, Any] | list[str]:
+    """Serialize a DatetimeIndex compactly when possible.
+
+    Regular indices are stored as ``{start, periods, freq}`` (~3 values).
+    Irregular indices fall back to a full ISO string list.
+    """
+    freq = pd.infer_freq(idx)
+    if freq is not None:
+        return {"start": idx[0].isoformat(), "periods": len(idx), "freq": freq}
+    return [t.isoformat() for t in idx]
+
+
+def _time_index_from_dict(
+    raw: dict[str, Any] | list[str],
+) -> pd.DatetimeIndex:
+    """Deserialize a DatetimeIndex from either compact or list format."""
+    if isinstance(raw, dict):
+        return pd.date_range(raw["start"], periods=raw["periods"], freq=raw["freq"])
+    return pd.DatetimeIndex(raw)
+
+
 class ClusterConfig:
     """Configuration for the clustering algorithm.
 
@@ -667,6 +688,9 @@ class ClusteringResult:
     extreme_cluster_indices: tuple[int, ...] | None = None
     weights: dict[str, float] | None = None
 
+    # === Index fields (for disaggregate() round-trip) ===
+    time_index: pd.DatetimeIndex | None = None
+
     # === Reference fields (for documentation, not used by apply()) ===
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
@@ -707,6 +731,7 @@ class ClusteringResult:
         rescale_cluster_periods: bool,
         rescale_exclude_columns: list[str] | None,
         extreme_cluster_idx: list[int],
+        time_index: pd.DatetimeIndex | None = None,
     ) -> ClusteringResult:
         """Build a ClusteringResult from pipeline intermediate data."""
         # Get cluster centers
@@ -772,6 +797,7 @@ class ClusteringResult:
             n_timesteps_per_period=n_timesteps_per_period,
             extreme_cluster_indices=extreme_cluster_indices_tuple,
             weights=dict(cluster_config.weights) if cluster_config.weights else None,
+            time_index=time_index,
             cluster_config=cluster_config,
             segment_config=segment_config,
             extremes_config=extremes_config,
@@ -932,6 +958,8 @@ class ClusteringResult:
             result["extreme_cluster_indices"] = list(self.extreme_cluster_indices)
         if self.weights is not None:
             result["weights"] = self.weights
+        if self.time_index is not None:
+            result["time_index"] = _time_index_to_dict(self.time_index)
         # Reference fields (optional, for documentation)
         if self.cluster_config is not None:
             result["cluster_config"] = self.cluster_config.to_dict()
@@ -977,6 +1005,9 @@ class ClusteringResult:
             kwargs["extreme_cluster_indices"] = tuple(data["extreme_cluster_indices"])
         if "weights" in data:
             kwargs["weights"] = data["weights"]
+        raw_time_index = data.get("time_index")
+        if raw_time_index is not None:
+            kwargs["time_index"] = _time_index_from_dict(raw_time_index)
         # Reference fields
         if "cluster_config" in data:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
@@ -1108,7 +1139,12 @@ class ClusteringResult:
         if is_segmented_input:
             data = _expand_segments_to_timesteps(data, self.segment_durations)  # type: ignore[arg-type]
 
-        return _expand_periods(data, self.cluster_assignments)
+        result = _expand_periods(data, self.cluster_assignments)
+
+        if self.time_index is not None and len(self.time_index) == len(result):
+            result.index = self.time_index
+
+        return result
 
     def apply(
         self,

--- a/src/tsam/pipeline/__init__.py
+++ b/src/tsam/pipeline/__init__.py
@@ -457,6 +457,12 @@ def _assemble_result(
 
     original_data_out = prepared.original_data[prepared.original_column_order]
 
+    input_time_index = (
+        original_data_out.index
+        if isinstance(original_data_out.index, pd.DatetimeIndex)
+        else None
+    )
+
     clustering_result = _ClusteringResult.from_pipeline(
         cluster_center_indices=clustered.cluster_center_indices,
         extreme_periods_info=clustered.extreme_periods_info,
@@ -472,6 +478,7 @@ def _assemble_result(
         rescale_cluster_periods=cfg.rescale_cluster_periods,
         rescale_exclude_columns=cfg.rescale_exclude_columns or [],
         extreme_cluster_idx=clustered.extreme_cluster_idx,
+        time_index=input_time_index,
     )
 
     return PipelineResult(

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -172,7 +172,6 @@ class AggregationResult:
     is_transferred: bool
     _original_data: pd.DataFrame = field(repr=False, compare=False)
     _reconstructed_data: pd.DataFrame = field(repr=False, compare=False)
-    _time_index: pd.Index = field(repr=False, compare=False)
     _accuracy_metrics: AccuracyMetrics | None = field(
         default=None, repr=False, compare=False
     )
@@ -189,6 +188,21 @@ class AggregationResult:
     )
     _segmented_df: pd.DataFrame | None = field(default=None, repr=False, compare=False)
     _weights: dict[str, float] | None = field(default=None, repr=False, compare=False)
+
+    @property
+    def _time_index(self) -> pd.Index:
+        padded_length = self.clustering.n_original_periods * self.n_timesteps_per_period
+        time_index = self.clustering.time_index
+        if time_index is None:
+            return pd.RangeIndex(stop=padded_length)
+        if len(time_index) == padded_length:
+            return time_index
+        # Input length wasn't a multiple of n_timesteps_per_period; extend to the
+        # padded length the pipeline produced internally.
+        freq = pd.infer_freq(time_index)
+        if freq is not None:
+            return pd.date_range(time_index[0], periods=padded_length, freq=freq)
+        return pd.RangeIndex(stop=padded_length)
 
     @cached_property
     def accuracy(self) -> AccuracyMetrics:

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -105,8 +105,20 @@ class TestAggregationResultDisaggregate:
 class TestClusteringResultDisaggregate:
     """Tests for ClusteringResult.disaggregate."""
 
-    def test_integer_index(self, result):
+    def test_datetime_index_restored(self, result):
         expanded = result.clustering.disaggregate(result.cluster_representatives)
+        if result.clustering.time_index is not None:
+            assert isinstance(expanded.index, pd.DatetimeIndex)
+            assert expanded.index.equals(result.clustering.time_index)
+        else:
+            assert isinstance(expanded.index, pd.RangeIndex)
+
+    def test_integer_index_when_no_time_index(self, result):
+        """Without time_index, disaggregate returns a RangeIndex."""
+        from dataclasses import replace
+
+        clustering_no_ti = replace(result.clustering, time_index=None)
+        expanded = clustering_no_ti.disaggregate(result.cluster_representatives)
         assert isinstance(expanded.index, pd.RangeIndex)
 
     def test_shape(self, result):
@@ -170,6 +182,32 @@ class TestClusteringResultDisaggregate:
         restored = loaded.disaggregate(result.cluster_representatives)
         np.testing.assert_array_equal(original.values, restored.values)
 
+    def test_io_roundtrip_preserves_time_index(self, result, tmp_path):
+        """JSON round-trip preserves the original DatetimeIndex."""
+        path = tmp_path / "clustering.json"
+        result.clustering.to_json(str(path))
+        loaded = ClusteringResult.from_json(str(path))
+
+        assert loaded.time_index is not None
+        assert loaded.time_index.equals(result.clustering.time_index)
+
+        restored = loaded.disaggregate(result.cluster_representatives)
+        assert isinstance(restored.index, pd.DatetimeIndex)
+        assert restored.index.equals(result.clustering.time_index)
+
+    def test_io_roundtrip_no_time_index(self, tmp_path):
+        """Old serialized files without time_index still work."""
+
+        cr = ClusteringResult(
+            period_duration=24.0,
+            cluster_assignments=(0, 1, 0, 1),
+            n_timesteps_per_period=24,
+        )
+        path = tmp_path / "clustering.json"
+        cr.to_json(str(path))
+        loaded = ClusteringResult.from_json(str(path))
+        assert loaded.time_index is None
+
     def test_io_roundtrip_segmented(self, result_segmented, tmp_path):
         path = tmp_path / "clustering.json"
         result_segmented.clustering.to_json(str(path))
@@ -185,6 +223,42 @@ class TestClusteringResultDisaggregate:
         )
         mask = ~np.isnan(original.values)
         np.testing.assert_array_equal(original.values[mask], restored.values[mask])
+
+
+class TestTimeIndexSerialization:
+    """Unit tests for _time_index_to_dict / _time_index_from_dict helpers."""
+
+    def test_regular_index_compact(self):
+        from tsam.config import _time_index_to_dict
+
+        idx = pd.date_range("2025-01-01", periods=8760, freq="h")
+        d = _time_index_to_dict(idx)
+        assert isinstance(d, dict)
+        assert set(d) == {"start", "periods", "freq"}
+        assert d["periods"] == 8760
+
+    def test_regular_index_roundtrip(self):
+        from tsam.config import _time_index_from_dict, _time_index_to_dict
+
+        idx = pd.date_range("2025-01-01", periods=8760, freq="h")
+        restored = _time_index_from_dict(_time_index_to_dict(idx))
+        pd.testing.assert_index_equal(idx, restored)
+
+    def test_irregular_index_fallback(self):
+        from tsam.config import _time_index_from_dict, _time_index_to_dict
+
+        idx = pd.DatetimeIndex(["2025-01-01", "2025-01-03", "2025-01-07"])
+        d = _time_index_to_dict(idx)
+        assert isinstance(d, list)
+        restored = _time_index_from_dict(d)
+        pd.testing.assert_index_equal(idx, restored)
+
+    def test_old_list_format_still_loads(self):
+        from tsam.config import _time_index_from_dict
+
+        raw = ["2025-01-01T00:00:00", "2025-01-01T01:00:00"]
+        restored = _time_index_from_dict(raw)
+        assert len(restored) == 2
 
 
 class TestDisaggregateEdgeCases:


### PR DESCRIPTION
## Summary
- Port #267 to `develop-v4`. Stores the input `DatetimeIndex` on `ClusteringResult` so it survives JSON round-trip and is restored by `disaggregate()`.
- Same efficient serialization as develop: `{start, periods, freq}` when the index has a regular frequency, ISO-string list fallback for irregular indices.
- Backward compatible — old JSON files without `time_index` continue to load.
- `apply()` automatically picks up the *new* data's index via the pipeline path (`_assemble_result` → `from_pipeline`), so the applied `ClusteringResult` carries its own time index without any extra wiring at the call site.

## Test plan
- [x] `pytest test/test_disaggregate.py` — 37 passed (includes the four new tests ported from develop plus the new `TestTimeIndexSerialization` unit-test class).
- [x] `pytest test/` — 558 passed, 112 skipped, 1 xpassed, no regressions.
- [x] `ruff` / `ruff format` / `mypy` pre-commit hooks pass.

Closes #311.