### PR TITLE
test: regression for apply() with weights that don't cover all columns

### DIFF
--- a/test/test_clustering_e2e.py
+++ b/test/test_clustering_e2e.py
@@ -438,6 +438,30 @@ class TestClusteringTransfer:
             input_data.columns
         )
 
+    def test_apply_with_weights_and_extra_columns(self, input_data):
+        """Apply clustering whose weights cover only a subset of the applied columns.
+
+        Regression for GH #276 (fixes #277 / #288 on develop): on the legacy
+        API this raised KeyError when accuracy_indicators iterated over
+        columns missing from weight_dict.
+
+        On v4 the bug is **architecturally unreachable**: pipeline/accuracy.py
+        compute_accuracy() operates on already-normalized data and never
+        subscripts a weights dict. This test is therefore a guard against a
+        future regression in pipeline design, not coverage of a currently
+        reachable code path. Safe to delete if a later refactor judges the
+        bug class permanently impossible to reintroduce.
+        """
+        wind_only = input_data[["Wind"]]
+        result_wind = aggregate(wind_only, n_clusters=8, weights={"Wind": 1.0})
+
+        # Apply to full data (extra columns absent from weights) — must not raise
+        result_full = result_wind.clustering.apply(input_data)
+
+        # Accuracy metrics must cover every column in the applied data
+        assert len(result_full.accuracy.rmse) == len(input_data.columns)
+        assert set(result_full.accuracy.rmse.index) == set(input_data.columns)
+
     def test_segmentation_preserved_in_transfer(self, input_data, tmp_path):
         """Test that segmentation info is preserved through JSON roundtrip."""
         from tsam import ClusteringResult


### PR DESCRIPTION
## Summary

Adds a v4-flavored counterpart to the GH #276 regression test that #277 / #288 added on `develop`. Mirrors the same scenario through the new functional API:

1. Cluster on a single column with explicit `weights={"Wind": 1.0}`.
2. Apply the resulting clustering to the full dataset (which has additional columns absent from the weights dict).
3. Assert no exception and that `accuracy.rmse` covers every column in the applied data.

## Why a fresh test instead of porting #277 verbatim

The legacy bug was a `KeyError` in `accuracyIndicators()` when iterating over columns missing from `weight_dict`. On v4 that bug is **architecturally unreachable** — `pipeline/accuracy.py::compute_accuracy` works on already-normalized data and never subscripts a weights dict.

The test is therefore explicitly framed as a guard against a future regression in pipeline design, not coverage of a currently reachable code path. The docstring notes this so a later cleanup pass can decide whether to prune it once the design is judged stable.

Companion to #313 (which added the equivalent regression test on the legacy API path of v4).

## Test plan

- [x] New test passes in isolation (`pytest test/test_clustering_e2e.py::TestClusteringTransfer::test_apply_with_weights_and_extra_columns`).
- [x] Full `test_clustering_e2e.py` still green (81 passed).
- [x] `pre-commit run --files test/test_clustering_e2e.py` passes (ruff, ruff-format, etc.).