### PR TITLE
fix: plot cluster_representatives for segmented results (#340)

### DIFF
--- a/src/tsam/plot.py
+++ b/src/tsam/plot.py
@@ -166,15 +166,26 @@ class ResultPlotAccessor:
             columns, available_columns, "cluster_representatives"
         )
 
-        # Reset index to get period/timestep as columns
+        # Reset index to get period/timestep as columns. The representatives
+        # index has 2 levels normally (period, timestep) but 3 with
+        # segmentation (period, segment step, segment duration). Name the
+        # first two levels and drop any extra segment-metadata levels so the
+        # column assignment matches the actual number of columns.
         df = typ[columns].reset_index()
-        df.columns = pd.Index(["Period", "Timestep", *columns])
+        n_index_levels = typ.index.nlevels
+        index_names = [
+            "Period",
+            "Timestep",
+            *[f"_extra_{i}" for i in range(n_index_levels - 2)],
+        ]
+        df.columns = pd.Index([*index_names, *columns])
 
         # Map period IDs to labels with weights
         df["Period"] = df["Period"].map(lambda p: f"Period {p} (n={weights.get(p, 1)})")
 
         long_df = df.melt(
             id_vars=["Period", "Timestep"],
+            value_vars=columns,
             var_name="Column",
             value_name="Value",
         )

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -70,6 +70,22 @@ class TestClusterRepresentatives:
         fig = result.plot.cluster_representatives(columns=[col])
         assert isinstance(fig, go.Figure)
 
+    def test_with_segmentation(self, result_segmented):
+        # Segmented results have a 3-level representatives index
+        # (period, segment step, segment duration); plotting must not crash.
+        fig = result_segmented.plot.cluster_representatives()
+        assert isinstance(fig, go.Figure)
+
+    def test_segmentation_trace_matches_data(self, result_segmented):
+        """Segmented representative trace contains the segment values."""
+        col = result_segmented.original.columns[0]
+        cluster_id = sorted(set(result_segmented.cluster_assignments))[0]
+        fig = result_segmented.plot.cluster_representatives(columns=[col])
+
+        expected = result_segmented.cluster_representatives.loc[cluster_id, col].values
+        trace = next(t for t in fig.data if f"Period {cluster_id} " in t.name)
+        np.testing.assert_array_almost_equal(np.asarray(trace.y, dtype=float), expected)
+
 
 # ---- cluster_members -------------------------------------------------------
 


### PR DESCRIPTION
Fixes #340.

### Problem

`result.plot.cluster_representatives()` raises `ValueError: Length mismatch: Expected axis has 4 elements, new values have 3 elements` on segmented (v4) results. `ResultPlotAccessor.cluster_representatives` assumes the representatives DataFrame has a 2-level `(period, timestep)` index and hardcodes the `reset_index()` column names to `["Period", "Timestep", *columns]`. With segmentation the index has 3 levels `(period, segment step, segment duration)`, so `reset_index()` yields one extra column and the assignment fails.

### Fix

Derive the index-level names from `typ.index.nlevels`: keep `Period`/`Timestep` for the first two levels and drop any extra segment-metadata levels, so the column assignment matches the actual width. Also pass `value_vars=columns` to `melt` so the dropped metadata columns can't leak into the plotted values. The segment x-axis becomes the segment step, consistent with `cluster_members`.

### Tests

Added a `TestClusterRepresentatives` segmentation case using the existing `result_segmented` fixture: the plot no longer crashes and the representative trace y-values match `cluster_representatives.loc[...]`. Without the fix both new tests fail with the length-mismatch; with it `test_plot.py` passes (35) and the full suite is green.

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
