### PR TITLE
ci: run mypy as a local hook against the project env (single source of truth)

### DIFF
--- a/.github/workflows/ci-develop.yaml
+++ b/.github/workflows/ci-develop.yaml
@@ -15,9 +15,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
+      # mypy runs as a repo:local hook against the project's own environment,
+      # so install the project before pre-commit runs. Other hooks use their
+      # own isolated envs and are unaffected.
+      - name: Install project (for the local mypy hook)
+        run: uv pip install --system ".[develop]"
       - uses: pre-commit/action@v3.0.1
 
   test:

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -16,9 +16,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
+      # mypy runs as a repo:local hook against the project's own environment,
+      # so install the project before pre-commit runs. Other hooks use their
+      # own isolated envs and are unaffected.
+      - name: Install project (for the local mypy hook)
+        run: uv pip install --system ".[develop]"
       - uses: pre-commit/action@v3.0.1
 
   # Extended PyPI cross-platform testing

--- a/.github/workflows/pre-commit-autofix.yaml
+++ b/.github/workflows/pre-commit-autofix.yaml
@@ -22,9 +22,18 @@ jobs:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
 
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
+
+      # mypy runs as a repo:local hook against the project's own environment,
+      # so install the project before pre-commit runs.
+      - name: Install project (for the local mypy hook)
+        run: uv pip install --system ".[develop]"
 
       - name: Run pre-commit (allow modifications)
         uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@
 # toggle it off in the pre-commit.ci dashboard (no config-only option exists).
 ci:
   autoupdate_schedule: quarterly
+  # The mypy hook below runs as a `repo: local` / system hook against the
+  # project's own environment, which pre-commit.ci cannot install. Skip it
+  # there; the "Pre-commit" GitHub Actions job runs mypy with `.[develop]`
+  # installed instead.
+  skip: [mypy]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -37,11 +42,22 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+  # mypy runs as a local/system hook against the project's own environment
+  # rather than pre-commit's isolated venv. This keeps mypy, pandas-stubs and
+  # numpy on the single versions pinned in pyproject.toml (the [develop] extra
+  # and runtime deps) — no duplicated pins, no rev to bump. The isolated-venv
+  # approach previously installed an unconstrained numpy (2.5.x) whose PEP 695
+  # stubs broke mypy under our python_version = "3.10" target.
+  #
+  # Requires `.[develop]` in the active env: CI installs it before running
+  # pre-commit, and pre-commit.ci skips this hook (see `ci.skip` above).
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies:
-          - pandas-stubs
+        name: mypy
+        entry: mypy
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
         args: [--ignore-missing-imports]
         exclude: ^(docs/|test/|benchmarks/)


### PR DESCRIPTION
## Problem
The `mirrors-mypy` pre-commit hook ran mypy in pre-commit's **isolated venv** (mypy + `pandas-stubs` only). `pandas-stubs` pulls in numpy transitively and **unconstrained**, so the env installed the latest numpy (2.5.x), whose PEP 695 `type` stubs mypy rejects under our `python_version = "3.10"` target:

```
.../numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

This broke the **Pre-commit** job on every open dependency PR (#358–#362) — and it was checking against a numpy the project doesn't even support (project pins `numpy<=2.4.6`). Bumping the hook to mypy 2.1.0 did **not** help: the gate is on the target Python version, not the mypy version.

## Fix
Run mypy as a `repo: local` / system hook against the **project's own environment** instead of an isolated venv. mypy, `pandas-stubs` and numpy now all come from the single versions pinned in `pyproject.toml` (the `[develop]` extra + runtime deps) — **one source of truth**, no duplicated pins, and no hook `rev` to keep in lockstep.

- `.pre-commit-config.yaml`: replace `mirrors-mypy` with a local mypy hook; add `ci.skip: [mypy]` so pre-commit.ci (which can't install the project) doesn't run it.
- `ci-develop` / `ci-master` / `pre-commit-autofix`: install `.[develop]` (uv, Python 3.12) before running pre-commit so the local hook resolves mypy and type-checks against the real deps.

## Verification (local)
- `.[develop]` resolves **numpy 2.4.6** + **mypy 2.1.0** + pandas-stubs.
- `pre-commit run mypy --all-files` → **Passed**; `mypy src/tsam` → no issues in 18 files.
- Reproduced the original failure with numpy 2.5.0 to confirm the cause.

Supersedes #364 (the Renovate lockstep for the hook rev is no longer needed — there's no rev). Closes the class of failures blocking #358–#362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)