### PR TITLE
chore(ci): keep mypy in lockstep across all sources via one conda-triggered PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,20 @@
             "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",
             "versioningTemplate": "pep440"
+        },
+        {
+            "customType": "regex",
+            "description": "Track the mirrors-mypy pre-commit hook rev against conda-forge/mypy instead of the GitHub tag. depName is `mypy`, so the custom.regex grouping rule below folds it into the single `mypy` PR alongside pyproject.toml and environment.yml. Resolving via conda means that PR only opens once mypy is on conda-forge (the slowest channel), which guarantees the matching mirrors-mypy `vX.Y.Z` tag and the PyPI release already exist — preventing the race where the hook bumps ahead of conda. The literal `v` tag prefix is matched outside the currentValue capture so it survives write-back (mirrors-mypy tags are `vX.Y.Z`; conda-forge versions are `X.Y.Z`). The built-in pre-commit manager is disabled for this hook in the packageRules below so the rev is not double-managed.",
+            "managerFilePatterns": [
+                "/(^|/)\\.pre-commit-config\\.yaml$/"
+            ],
+            "matchStrings": [
+                "pre-commit/mirrors-mypy\\s+rev:\\s*v(?<currentValue>\\d[^\\s#]*)"
+            ],
+            "depNameTemplate": "mypy",
+            "packageNameTemplate": "conda-forge/mypy",
+            "datasourceTemplate": "conda",
+            "versioningTemplate": "pep440"
         }
     ],
     "packageRules": [
@@ -109,6 +123,12 @@
             "matchManagers": ["pre-commit"],
             "groupName": "pre-commit hooks",
             "commitMessageTopic": "pre-commit hooks"
+        },
+        {
+            "description": "mirrors-mypy is tracked via the conda-forge customManager above (gated on conda-forge availability and grouped into the single `mypy` PR); disable the built-in pre-commit manager for it so the rev is not double-managed.",
+            "matchManagers": ["pre-commit"],
+            "matchDepNames": ["pre-commit/mirrors-mypy"],
+            "enabled": false
         }
     ],
     "vulnerabilityAlerts": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
## What
Makes Renovate manage the `mirrors-mypy` pre-commit hook through the **conda-forge** datasource (like `pyproject.toml` and `environment.yml` already are) instead of the GitHub tag, and disables the built-in `pre-commit` manager for that one hook so the rev isn't double-managed.

## Why
Today mypy lives in three places under two managers:

| Source | Manager | Trigger |
|---|---|---|
| `pyproject.toml` / `environment.yml` | `custom.regex` → conda-forge | conda release |
| `.pre-commit-config.yaml` (`mirrors-mypy` rev) | built-in `pre-commit` → GitHub tag | GitHub tag |

Different managers, different triggers → they drift. That's how the hook got stuck at `v1.20.2` while the project moved to `2.1.0` (the bump in #308 was closed, Renovate never re-raised it), which broke CI on every open dependency PR. See #363 for the immediate fix.

## How this fixes it
The new `custom.regex` manager uses `depName: mypy`, so the existing grouping rule (`matchManagers: [pep621, custom.regex]`, `groupName: {{depName}}`) folds the hook into the **single `mypy` PR** with the other two sources.

Resolving the hook via `conda-forge/mypy` means that combined PR only opens **once mypy is released on conda-forge** — the slowest of the three channels — which guarantees the matching `mirrors-mypy vX.Y.Z` tag and PyPI release already exist. No race, no partial bumps: all three move together or not at all.

The literal `v` tag prefix is matched *outside* the `currentValue` capture, so it's preserved on write-back (`mirrors-mypy` tags are `vX.Y.Z`; conda versions are `X.Y.Z`).

Validated locally with `renovate-config-validator` (passes).

## Note for reviewers
Stacked on #363 (so CI here runs against the fixed hook and stays green). Please **merge #363 first**; GitHub will then auto-retarget this PR to `develop`. The diff here is `.github/renovate.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)