### PR TITLE
refactor: rename shadowed loop var in KMaxoids.k_maxoids

### DIFF
--- a/src/tsam/algorithms/k_maxoids.py
+++ b/src/tsam/algorithms/k_maxoids.py
@@ -94,7 +94,7 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
         n, _m = X.shape
         inertia_best = None
 
-        for i in range(n_init):
+        for restart in range(n_init):
             inds = rnd.permutation(np.arange(n))
 
             X = X[inds]
@@ -103,22 +103,22 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
                 for j in range(n):
                     x = X[j]
                     D = np.sum((M - x) ** 2, axis=1)
-                    i = np.argmin(D)
-                    d = np.sum((M - M[i]) ** 2, axis=1)
+                    nearest = np.argmin(D)
+                    d = np.sum((M - M[nearest]) ** 2, axis=1)
 
                     if do_logarithmic:
-                        D[i] = 1.0
-                        d[i] = 1.0
+                        D[nearest] = 1.0
+                        d[nearest] = 1.0
                         valx = np.prod(D)
                         valm = np.prod(d)
                     else:
-                        D[i] = 0.0
-                        d[i] = 0.0
+                        D[nearest] = 0.0
+                        d[nearest] = 0.0
                         valx = np.sum(D)
                         valm = np.sum(d)
 
                     if valx > valm:
-                        M[i] = x
+                        M[nearest] = x
 
             d_temp = self.distance_func(x_old, Y=list(M))
             inertia_temp = np.sum(np.min(d_temp, axis=1))


### PR DESCRIPTION
## What

In `KMaxoids.k_maxoids`, the outer restart-loop counter `i` was silently reused as the nearest-center index returned by `np.argmin(D)` inside the inner loop:

```python
for i in range(n_init):        # outer: restart counter
    ...
    for t in range(n_passes):
        for j in range(n):
            ...
            i = np.argmin(D)   # shadows the restart counter
```

This is harmless today (the outer `i` is never read after the inner loop) but hurts readability and is a latent bug if the restart index is ever needed.

## Change

Pure rename, **no behavior change**:
- outer loop `for i` → `for restart`
- nearest-center index `i` → `nearest` (and all its uses)

## Testing

`pytest -k "maxoid or k_maxoids"` → 17 passed, 10 skipped (optional-dep skips).

## Notes

- Landed directly on the v4 line rather than `develop`: the file was relocated/restructured in v4 (`utils/` → `algorithms/k_maxoids.py`), so a `develop` fix wouldn't port cleanly, and this is not a v3 regression.

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)