### PR TITLE
refactor: rename Distribution scope "cluster" → "local" (deprecate alias)

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -165,7 +165,7 @@ The table below maps every old parameter to its v3 equivalent.
 | `addPeakMin` | `ExtremeConfig(min_value=...)` | |
 | `addMeanMax` | `ExtremeConfig(max_period=...)` | |
 | `addMeanMin` | `ExtremeConfig(min_period=...)` | |
-| `distributionPeriodWise` | `Distribution(scope="cluster"\|"global")` | See [representation objects](#typed-representation-objects). |
+| `distributionPeriodWise` | `Distribution(scope="local"\|"global")` | See [representation objects](#typed-representation-objects). |
 | `representationDict` | `MinMaxMean(max_columns=[...], min_columns=[...])` | See [representation objects](#typed-representation-objects). |
 
 ### Cluster method values { #cluster-method-values }

--- a/src/tsam/algorithms/representations.py
+++ b/src/tsam/algorithms/representations.py
@@ -62,7 +62,7 @@ def representations(
 
     # --- Dispatch on Representation objects first ---
     if isinstance(representation_method, Distribution):
-        period_wise = representation_method.scope == "cluster"
+        period_wise = representation_method.scope == "local"
         cluster_centers = duration_representation(
             candidates,
             cluster_order,

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal, get_args
 
@@ -43,21 +44,43 @@ class Distribution:
 
     Parameters
     ----------
-    scope : "cluster" or "global", default "cluster"
-        "cluster": preserve each cluster's distribution separately
-        "global": preserve the overall time series distribution
+    scope : "local" or "global", default "local"
+        "local": preserve each group's own distribution separately. The group is
+        a cluster of periods for a cluster representation, or a segment of
+        timesteps for a segment representation.
+        "global": preserve only the distribution of the enclosing whole (the
+        full time series for a cluster representation, a single period for a
+        segment representation).
+
+        ``"cluster"`` is accepted as a deprecated alias for ``"local"`` (the old
+        name, which was misleading for segment representations where the group is
+        a segment, not a cluster).
     preserve_minmax : bool, default False
         If True, also preserves min/max values per timestep
         (equivalent to old "distribution_minmax").
     """
 
-    scope: Literal["cluster", "global"] = "cluster"
+    # "cluster" is a deprecated alias for "local"; normalized in __post_init__.
+    scope: Literal["local", "global", "cluster"] = "local"
     preserve_minmax: bool = False
+
+    def __post_init__(self) -> None:
+        if self.scope == "cluster":
+            warnings.warn(
+                'Distribution scope="cluster" is deprecated; use scope="local" '
+                "instead (the two are equivalent). The name was renamed because "
+                '"cluster" is misleading for segment representations, where the '
+                "group being preserved is a segment, not a cluster.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # frozen dataclass: normalize the deprecated alias in place.
+            object.__setattr__(self, "scope", "local")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         result: dict[str, Any] = {"type": "distribution"}
-        if self.scope != "cluster":
+        if self.scope != "local":
             result["scope"] = self.scope
         if self.preserve_minmax:
             result["preserve_minmax"] = self.preserve_minmax
@@ -67,7 +90,7 @@ class Distribution:
     def from_dict(cls, data: dict) -> Distribution:
         """Create from dictionary (e.g., loaded from JSON)."""
         return cls(
-            scope=data.get("scope", "cluster"),
+            scope=data.get("scope", "local"),
             preserve_minmax=data.get("preserve_minmax", False),
         )
 
@@ -158,10 +181,11 @@ class ClusterConfig:
         - "minmax_mean": Combine min/max/mean per timestep
 
         Typed objects (for additional options):
-        - ``Distribution(scope="cluster"|"global", preserve_minmax=False)``:
+        - ``Distribution(scope="local"|"global", preserve_minmax=False)``:
           Preserve value distribution. ``scope`` controls whether each
-          cluster's distribution is preserved separately ("cluster") or
-          the overall time series distribution ("global").
+          cluster's distribution is preserved separately ("local") or
+          only the overall time series distribution ("global"). ``"cluster"``
+          is a deprecated alias for ``"local"``.
         - ``MinMaxMean(max_columns=[...], min_columns=[...])``:
           Combine min/max/mean per column. Columns not listed default to mean.
 

--- a/test/test_distribution_scope.py
+++ b/test/test_distribution_scope.py
@@ -1,0 +1,76 @@
+"""Tests for the ``Distribution.scope`` rename ("cluster" -> "local").
+
+``scope="cluster"`` was renamed to ``scope="local"`` because "cluster" is
+misleading for segment representations, where the group whose distribution is
+preserved is a segment, not a cluster. ``"cluster"`` remains accepted as a
+deprecated, behaviourally-identical alias.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from conftest import TESTDATA_CSV
+from tsam import ClusterConfig, Distribution, aggregate
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:KMeans is known to have a memory leak on Windows with MKL.*:UserWarning"
+    ),
+]
+
+
+def test_default_scope_is_local():
+    assert Distribution().scope == "local"
+
+
+def test_local_and_global_do_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert Distribution(scope="local").scope == "local"
+        assert Distribution(scope="global").scope == "global"
+
+
+def test_cluster_alias_warns_and_normalizes_to_local():
+    with pytest.warns(DeprecationWarning, match='scope="cluster" is deprecated'):
+        dist = Distribution(scope="cluster")
+    assert dist.scope == "local"
+
+
+def test_to_dict_omits_default_and_normalized_scope():
+    # "local" is the default, so it is omitted from the serialized form.
+    assert "scope" not in Distribution(scope="local").to_dict()
+    with pytest.warns(DeprecationWarning):
+        assert "scope" not in Distribution(scope="cluster").to_dict()
+    # "global" is non-default and is serialized.
+    assert Distribution(scope="global").to_dict()["scope"] == "global"
+
+
+def test_from_dict_accepts_deprecated_and_missing_scope():
+    assert Distribution.from_dict({}).scope == "local"
+    assert Distribution.from_dict({"scope": "global"}).scope == "global"
+    with pytest.warns(DeprecationWarning):
+        assert Distribution.from_dict({"scope": "cluster"}).scope == "local"
+
+
+def test_cluster_alias_is_behaviourally_identical_to_local():
+    """The deprecated alias must produce bit-for-bit identical aggregation output."""
+    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+    def run(scope):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return aggregate(
+                raw,
+                n_clusters=8,
+                period_duration=24,
+                cluster=ClusterConfig(
+                    method="hierarchical",
+                    use_duration_curves=False,
+                    representation=Distribution(scope=scope),
+                ),
+                preserve_column_means=False,
+            ).reconstructed
+
+    pd.testing.assert_frame_equal(run("cluster"), run("local"))


### PR DESCRIPTION
## Summary

Renames `Distribution(scope="cluster")` → `Distribution(scope="local")`. `"cluster"` is a **misleading name** for **segment** representations, where the group whose distribution is preserved is a *segment*, not a cluster.

The knob is stage-neutral, so the name should be too:
- **`"local"`** — preserve each *group's own* distribution. The group is a **cluster of periods** for a cluster representation, or a **segment of timesteps** for a segment representation.
- **`"global"`** — preserve only the **enclosing whole's** distribution (the full time series for a cluster rep; a single period for a segment rep). Unchanged.

## Backwards compatibility

Fully backwards compatible:
- `"cluster"` is still accepted as a **deprecated alias**, normalized to `"local"` in `Distribution.__post_init__` with a `DeprecationWarning`.
- `to_dict` / `from_dict` and the internal `period_wise` mapping use the new value.
- A behavioural-equivalence test asserts `scope="cluster"` produces **bit-for-bit identical** aggregation output to `scope="local"`.

Serialization stays clean: `to_dict` omits `scope` when it equals the default, so existing JSON (which only ever stored `"global"` explicitly) is unaffected.

## Why now

`develop-v4` hasn't released, so renaming costs no downstream deprecation cycle — this is the cheapest moment to fix the name, while keeping the alias for any in-flight code.

## Not in scope

This is a pure, no-behaviour-change rename. The silent `preserve_minmax` no-op for `scope="local"`/`"cluster"` **segment** representations (#378) is a separate, orthogonal concern and will be a follow-up on top of the concurrency PR (#377), where the segment guard lives.

## Test plan
- [x] New `test/test_distribution_scope.py`: default is `"local"`; `"cluster"` warns + normalizes; `to_dict`/`from_dict` round-trips; behavioural equivalence of the alias.
- [x] Existing representation, serialization, and golden-regression suites pass (200 passed, 111 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)