### PR TITLE
refactor: rename Distribution scope "local" + clarify segment options (#378, #382)

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -65,7 +65,11 @@ them against the cap. This is two independent changes with different scopes:
       (previously it could drift by a few percent, especially without rescaling).
     - Single-value segments (`distribution_minmax` with `n_segments`) keep the
       segment **mean** rather than being pushed to the segment maximum, since one
-      value cannot carry both the minimum and the maximum.
+      value cannot carry both the minimum and the maximum. Because a segment is a
+      single value, `Distribution(scope="local")` as a *segment* representation is
+      equivalent to `"mean"`, and `preserve_minmax` only takes effect with
+      `scope="global"` — `SegmentConfig` now emits a `UserWarning` if you set
+      `preserve_minmax=True` with `scope="local"`.
 2. **Cluster-period rescaling.** Because `preserve_column_means` **defaults to
    `True`**, this step runs in almost every aggregation, on the shared path for
    **every** representation — it is not an opt-in corner case. It is identical to
@@ -117,6 +121,12 @@ configuration. Passing `weights=` to `ClusterConfig` now raises `TypeError`.
 - `result.plot.cluster_weights()` is renamed to `result.plot.cluster_counts()`,
   matching the `AggregationResult.cluster_counts` attribute. The old name still
   works but emits a `FutureWarning` and will be removed in a future release.
+- `Distribution(scope="cluster")` is renamed to `Distribution(scope="local")`.
+  `"cluster"` was misleading for **segment** representations, where the group
+  whose distribution is preserved is a segment, not a cluster; `"local"` is
+  stage-neutral (each group's own distribution) versus `"global"` (the enclosing
+  whole's). The old value still works — it is normalized to `"local"` and emits a
+  `FutureWarning` — and is behaviourally identical.
 
 ### Internal changes (no action required)
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -210,7 +210,7 @@ The table below maps every old parameter to its v3 equivalent.
 | `addPeakMin` | `ExtremeConfig(min_value=...)` | |
 | `addMeanMax` | `ExtremeConfig(max_period=...)` | |
 | `addMeanMin` | `ExtremeConfig(min_period=...)` | |
-| `distributionPeriodWise` | `Distribution(scope="cluster"\|"global")` | See [representation objects](#typed-representation-objects). |
+| `distributionPeriodWise` | `Distribution(scope="local"\|"global")` | See [representation objects](#typed-representation-objects). |
 | `representationDict` | `MinMaxMean(max_columns=[...], min_columns=[...])` | See [representation objects](#typed-representation-objects). |
 
 ### Cluster method values { #cluster-method-values }

--- a/src/tsam/algorithms/representations.py
+++ b/src/tsam/algorithms/representations.py
@@ -63,7 +63,7 @@ def representations(
 
     # --- Dispatch on Representation objects first ---
     if isinstance(representation_method, Distribution):
-        period_wise = representation_method.scope == "cluster"
+        period_wise = representation_method.scope == "local"
         cluster_centers = duration_representation(
             candidates,
             cluster_order,

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -63,7 +63,7 @@ class Distribution:
         this attribute is applied to all attributes, preserving their
         concurrency (co-incidence in time) with the reference attribute while
         each attribute still fits its own distribution. Only valid with
-        ``scope="cluster"``. Equivalent to ``concurrency="reference"``.
+        ``scope="local"``. Equivalent to ``concurrency="reference"``.
     concurrency : {"independent", "reference", "medoid", "consensus", \
 "assignment"}, optional
         Strategy used to derive the synthetic time axis. All strategies preserve
@@ -80,7 +80,7 @@ class Distribution:
         - ``"assignment"``: optimal single ordering minimising total deviation
           from the cluster mean profile across all attributes.
 
-        Only valid with ``scope="cluster"``. If None, resolves to ``"reference"``
+        Only valid with ``scope="local"``. If None, resolves to ``"reference"``
         when ``reference_attribute`` is given, otherwise ``"independent"``.
 
     Notes
@@ -88,7 +88,7 @@ class Distribution:
     When used as a segment representation (``SegmentConfig.representation``),
     each segment is a single value per attribute, which constrains two options:
     ``preserve_minmax`` only takes effect with ``scope="global"`` (a single
-    value cannot carry both min and max, so ``scope="cluster"`` keeps the
+    value cannot carry both min and max, so ``scope="local"`` keeps the
     integral-preserving mean), and ``concurrency`` / ``reference_attribute`` are
     not supported (there is no within-period time axis left to order — set them
     on the cluster representation, where ordering runs before segmentation).
@@ -103,22 +103,6 @@ class Distribution:
     ) = None
 
     def __post_init__(self) -> None:
-        if self.reference_attribute is not None and self.scope != "cluster":
-            raise ValueError(
-                "reference_attribute is only supported with scope='cluster'."
-            )
-        if (
-            self.concurrency is not None
-            and self.concurrency != "independent"
-            and self.scope != "cluster"
-        ):
-            raise ValueError("concurrency is only supported with scope='cluster'.")
-        if self.concurrency == "reference" and self.reference_attribute is None:
-            raise ValueError(
-                "concurrency='reference' requires reference_attribute to be set."
-            )
-
-    def __post_init__(self) -> None:
         if self.scope == "cluster":
             warnings.warn(
                 'Distribution scope="cluster" is deprecated; use scope="local" '
@@ -130,6 +114,20 @@ class Distribution:
             )
             # frozen dataclass: normalize the deprecated alias in place.
             object.__setattr__(self, "scope", "local")
+        if self.reference_attribute is not None and self.scope != "local":
+            raise ValueError(
+                "reference_attribute is only supported with scope='local'."
+            )
+        if (
+            self.concurrency is not None
+            and self.concurrency != "independent"
+            and self.scope != "local"
+        ):
+            raise ValueError("concurrency is only supported with scope='local'.")
+        if self.concurrency == "reference" and self.reference_attribute is None:
+            raise ValueError(
+                "concurrency='reference' requires reference_attribute to be set."
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -125,7 +125,7 @@ class Distribution:
                 "instead (the two are equivalent). The name was renamed because "
                 '"cluster" is misleading for segment representations, where the '
                 "group being preserved is a segment, not a cluster.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
             # frozen dataclass: normalize the deprecated alias in place.

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal, get_args
 
@@ -43,9 +44,17 @@ class Distribution:
 
     Parameters
     ----------
-    scope : "cluster" or "global", default "cluster"
-        "cluster": preserve each cluster's distribution separately
-        "global": preserve the overall time series distribution
+    scope : "local" or "global", default "local"
+        "local": preserve each group's own distribution separately. The group is
+        a cluster of periods for a cluster representation, or a segment of
+        timesteps for a segment representation.
+        "global": preserve only the distribution of the enclosing whole (the
+        full time series for a cluster representation, a single period for a
+        segment representation).
+
+        ``"cluster"`` is accepted as a deprecated alias for ``"local"`` (the old
+        name, which was misleading for segment representations where the group is
+        a segment, not a cluster).
     preserve_minmax : bool, default False
         If True, also preserves min/max values per timestep
         (equivalent to old "distribution_minmax").
@@ -85,7 +94,8 @@ class Distribution:
     on the cluster representation, where ordering runs before segmentation).
     """
 
-    scope: Literal["cluster", "global"] = "cluster"
+    # "cluster" is a deprecated alias for "local"; normalized in __post_init__.
+    scope: Literal["local", "global", "cluster"] = "local"
     preserve_minmax: bool = False
     reference_attribute: str | None = None
     concurrency: (
@@ -108,10 +118,23 @@ class Distribution:
                 "concurrency='reference' requires reference_attribute to be set."
             )
 
+    def __post_init__(self) -> None:
+        if self.scope == "cluster":
+            warnings.warn(
+                'Distribution scope="cluster" is deprecated; use scope="local" '
+                "instead (the two are equivalent). The name was renamed because "
+                '"cluster" is misleading for segment representations, where the '
+                "group being preserved is a segment, not a cluster.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # frozen dataclass: normalize the deprecated alias in place.
+            object.__setattr__(self, "scope", "local")
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         result: dict[str, Any] = {"type": "distribution"}
-        if self.scope != "cluster":
+        if self.scope != "local":
             result["scope"] = self.scope
         if self.preserve_minmax:
             result["preserve_minmax"] = self.preserve_minmax
@@ -125,7 +148,7 @@ class Distribution:
     def from_dict(cls, data: dict) -> Distribution:
         """Create from dictionary (e.g., loaded from JSON)."""
         return cls(
-            scope=data.get("scope", "cluster"),
+            scope=data.get("scope", "local"),
             preserve_minmax=data.get("preserve_minmax", False),
             reference_attribute=data.get("reference_attribute"),
             concurrency=data.get("concurrency"),
@@ -218,10 +241,11 @@ class ClusterConfig:
         - "minmax_mean": Combine min/max/mean per timestep
 
         Typed objects (for additional options):
-        - ``Distribution(scope="cluster"|"global", preserve_minmax=False)``:
+        - ``Distribution(scope="local"|"global", preserve_minmax=False)``:
           Preserve value distribution. ``scope`` controls whether each
-          cluster's distribution is preserved separately ("cluster") or
-          the overall time series distribution ("global").
+          cluster's distribution is preserved separately ("local") or
+          only the overall time series distribution ("global"). ``"cluster"``
+          is a deprecated alias for ``"local"``.
         - ``MinMaxMean(max_columns=[...], min_columns=[...])``:
           Combine min/max/mean per column. Columns not listed default to mean.
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -397,9 +397,23 @@ class SegmentConfig:
         - "mean": Average value of timesteps in segment
         - "medoid": Actual timestep closest to segment mean
         - "distribution": Preserve distribution within segment
-        - ``Distribution(...)``: Distribution with additional options; some
-          behave differently for single-value segments, see :class:`Distribution`
+        - ``Distribution(...)``: Distribution with additional options (see Notes)
         - ``MinMaxMean(...)``: Per-column min/max/mean
+
+    Notes
+    -----
+    A segment collapses each attribute to a **single value**, so the
+    ``Distribution`` options behave differently than for a cluster
+    representation:
+
+    - ``scope="local"`` (the default) is equivalent to ``"mean"`` — each
+      segment's single value is the mean of its timesteps. Only
+      ``scope="global"`` produces a distinct result (it matches the whole
+      period's value distribution rather than each segment's mean).
+    - ``preserve_minmax`` only takes effect with ``scope="global"``; a single
+      value cannot carry both the min and the max, so with ``scope="local"`` it
+      is silently ignored and the integral-preserving mean is kept (a
+      ``UserWarning`` is emitted).
     """
 
     n_segments: int
@@ -410,6 +424,20 @@ class SegmentConfig:
             raise ValueError(f"n_segments must be positive, got {self.n_segments}")
         # Note: Upper bound validation (n_segments <= timesteps_per_period)
         # is performed in api.aggregate() when period_duration is known.
+        if (
+            isinstance(self.representation, Distribution)
+            and self.representation.preserve_minmax
+            and self.representation.scope == "local"
+        ):
+            warnings.warn(
+                'preserve_minmax has no effect on a scope="local" segment '
+                "representation: each segment collapses to a single value per "
+                "attribute, which cannot carry both the min and the max, so the "
+                'integral-preserving mean is kept. Use scope="global" to preserve '
+                "segment min/max.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""

--- a/test/test_concurrencyRepresentation.py
+++ b/test/test_concurrencyRepresentation.py
@@ -130,7 +130,7 @@ def _aggregate(raw, concurrency, *, preserve_minmax=False, rescale=False, **rep_
             method="hierarchical",
             use_duration_curves=False,
             representation=Distribution(
-                scope="cluster",
+                scope="local",
                 preserve_minmax=preserve_minmax,
                 concurrency=concurrency,
                 **rep_kw,
@@ -192,8 +192,8 @@ def test_periodwise_minmax_preserves_integral_without_rescaling(concurrency):
 def test_concurrency_validation_errors():
     raw = pd.read_csv(TESTDATA_CSV, index_col=0)
 
-    # concurrency (non-independent) requires scope='cluster' — caught in config
-    with pytest.raises(ValueError, match="scope='cluster'"):
+    # concurrency (non-independent) requires scope='local' — caught in config
+    with pytest.raises(ValueError, match="scope='local'"):
         Distribution(scope="global", concurrency="medoid")
 
     # global scope reaches the algorithm guard for an explicit non-independent
@@ -212,7 +212,7 @@ def test_distribution_config_concurrency_roundtrip():
     assert dist_ref.to_dict()["reference_attribute"] == "Load"
     assert Distribution.from_dict(dist_ref.to_dict()).reference_attribute == "Load"
 
-    with pytest.raises(ValueError, match="scope='cluster'"):
+    with pytest.raises(ValueError, match="scope='local'"):
         Distribution(scope="global", concurrency="medoid")
 
     with pytest.raises(ValueError, match="requires reference_attribute"):

--- a/test/test_distribution_scope.py
+++ b/test/test_distribution_scope.py
@@ -38,14 +38,14 @@ class TestScopeRename:
             assert Distribution(scope="global").scope == "global"
 
     def test_cluster_alias_warns_and_normalizes_to_local(self):
-        with pytest.warns(DeprecationWarning, match='scope="cluster" is deprecated'):
+        with pytest.warns(FutureWarning, match='scope="cluster" is deprecated'):
             dist = Distribution(scope="cluster")
         assert dist.scope == "local"
 
     def test_to_dict_omits_default_and_normalized_scope(self):
         # "local" is the default, so it is omitted from the serialized form.
         assert "scope" not in Distribution(scope="local").to_dict()
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(FutureWarning):
             assert "scope" not in Distribution(scope="cluster").to_dict()
         # "global" is non-default and is serialized.
         assert Distribution(scope="global").to_dict()["scope"] == "global"
@@ -53,7 +53,7 @@ class TestScopeRename:
     def test_from_dict_accepts_deprecated_and_missing_scope(self):
         assert Distribution.from_dict({}).scope == "local"
         assert Distribution.from_dict({"scope": "global"}).scope == "global"
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(FutureWarning):
             assert Distribution.from_dict({"scope": "cluster"}).scope == "local"
 
     def test_cluster_alias_is_behaviourally_identical_to_local(self):
@@ -62,7 +62,7 @@ class TestScopeRename:
 
         def run(scope):
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
+                warnings.simplefilter("ignore", FutureWarning)
                 return aggregate(
                     raw,
                     n_clusters=8,
@@ -114,9 +114,9 @@ class TestSegmentDistribution:
             SegmentConfig(n_segments=4, representation=Distribution(scope="local"))
 
     def test_deprecated_cluster_alias_also_warns_on_segment(self):
-        # "cluster" normalizes to "local" (DeprecationWarning), then the segment
+        # "cluster" normalizes to "local" (FutureWarning), then the segment
         # preserve_minmax no-op warning fires too.
-        with pytest.warns((DeprecationWarning, UserWarning)):
+        with pytest.warns((FutureWarning, UserWarning)):
             SegmentConfig(
                 n_segments=4,
                 representation=Distribution(scope="cluster", preserve_minmax=True),

--- a/test/test_distribution_scope.py
+++ b/test/test_distribution_scope.py
@@ -1,9 +1,13 @@
-"""Tests for the ``Distribution.scope`` rename ("cluster" -> "local").
+"""Tests for the ``Distribution.scope`` rename and its segment semantics.
 
 ``scope="cluster"`` was renamed to ``scope="local"`` because "cluster" is
 misleading for segment representations, where the group whose distribution is
 preserved is a segment, not a cluster. ``"cluster"`` remains accepted as a
 deprecated, behaviourally-identical alias.
+
+For a segment (a single value per attribute) the ``Distribution`` options
+collapse: ``scope="local"`` equals ``"mean"`` and ``preserve_minmax`` cannot
+take effect (issues #378, #382).
 """
 
 import warnings
@@ -12,7 +16,7 @@ import pandas as pd
 import pytest
 
 from conftest import TESTDATA_CSV
-from tsam import ClusterConfig, Distribution, aggregate
+from tsam import ClusterConfig, Distribution, SegmentConfig, aggregate
 
 pytestmark = [
     pytest.mark.filterwarnings(
@@ -21,56 +25,119 @@ pytestmark = [
 ]
 
 
-def test_default_scope_is_local():
-    assert Distribution().scope == "local"
+class TestScopeRename:
+    """The ``"cluster"`` -> ``"local"`` rename and its deprecated alias."""
 
+    def test_default_scope_is_local(self):
+        assert Distribution().scope == "local"
 
-def test_local_and_global_do_not_warn():
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        assert Distribution(scope="local").scope == "local"
-        assert Distribution(scope="global").scope == "global"
-
-
-def test_cluster_alias_warns_and_normalizes_to_local():
-    with pytest.warns(DeprecationWarning, match='scope="cluster" is deprecated'):
-        dist = Distribution(scope="cluster")
-    assert dist.scope == "local"
-
-
-def test_to_dict_omits_default_and_normalized_scope():
-    # "local" is the default, so it is omitted from the serialized form.
-    assert "scope" not in Distribution(scope="local").to_dict()
-    with pytest.warns(DeprecationWarning):
-        assert "scope" not in Distribution(scope="cluster").to_dict()
-    # "global" is non-default and is serialized.
-    assert Distribution(scope="global").to_dict()["scope"] == "global"
-
-
-def test_from_dict_accepts_deprecated_and_missing_scope():
-    assert Distribution.from_dict({}).scope == "local"
-    assert Distribution.from_dict({"scope": "global"}).scope == "global"
-    with pytest.warns(DeprecationWarning):
-        assert Distribution.from_dict({"scope": "cluster"}).scope == "local"
-
-
-def test_cluster_alias_is_behaviourally_identical_to_local():
-    """The deprecated alias must produce bit-for-bit identical aggregation output."""
-    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
-
-    def run(scope):
+    def test_local_and_global_do_not_warn(self):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.simplefilter("error")
+            assert Distribution(scope="local").scope == "local"
+            assert Distribution(scope="global").scope == "global"
+
+    def test_cluster_alias_warns_and_normalizes_to_local(self):
+        with pytest.warns(DeprecationWarning, match='scope="cluster" is deprecated'):
+            dist = Distribution(scope="cluster")
+        assert dist.scope == "local"
+
+    def test_to_dict_omits_default_and_normalized_scope(self):
+        # "local" is the default, so it is omitted from the serialized form.
+        assert "scope" not in Distribution(scope="local").to_dict()
+        with pytest.warns(DeprecationWarning):
+            assert "scope" not in Distribution(scope="cluster").to_dict()
+        # "global" is non-default and is serialized.
+        assert Distribution(scope="global").to_dict()["scope"] == "global"
+
+    def test_from_dict_accepts_deprecated_and_missing_scope(self):
+        assert Distribution.from_dict({}).scope == "local"
+        assert Distribution.from_dict({"scope": "global"}).scope == "global"
+        with pytest.warns(DeprecationWarning):
+            assert Distribution.from_dict({"scope": "cluster"}).scope == "local"
+
+    def test_cluster_alias_is_behaviourally_identical_to_local(self):
+        """The deprecated alias produces bit-for-bit identical aggregation output."""
+        raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+        def run(scope):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return aggregate(
+                    raw,
+                    n_clusters=8,
+                    period_duration=24,
+                    cluster=ClusterConfig(
+                        method="hierarchical",
+                        use_duration_curves=False,
+                        representation=Distribution(scope=scope),
+                    ),
+                    preserve_column_means=False,
+                ).reconstructed
+
+        pd.testing.assert_frame_equal(run("cluster"), run("local"))
+
+
+class TestSegmentDistribution:
+    """Distribution options collapse for segments (single value per attribute)."""
+
+    @staticmethod
+    def _reconstructed(seg_rep):
+        raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             return aggregate(
                 raw,
                 n_clusters=8,
                 period_duration=24,
-                cluster=ClusterConfig(
-                    method="hierarchical",
-                    use_duration_curves=False,
-                    representation=Distribution(scope=scope),
-                ),
+                cluster=ClusterConfig(method="hierarchical", use_duration_curves=False),
+                segments=SegmentConfig(n_segments=6, representation=seg_rep),
                 preserve_column_means=False,
             ).reconstructed
 
-    pd.testing.assert_frame_equal(run("cluster"), run("local"))
+    def test_preserve_minmax_warns_on_local_segment(self):
+        with pytest.warns(UserWarning, match="preserve_minmax has no effect"):
+            SegmentConfig(
+                n_segments=4,
+                representation=Distribution(scope="local", preserve_minmax=True),
+            )
+
+    def test_preserve_minmax_does_not_warn_on_global_segment(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # scope="global" pins segment min/max, so preserve_minmax is honoured.
+            SegmentConfig(
+                n_segments=4,
+                representation=Distribution(scope="global", preserve_minmax=True),
+            )
+            # scope="local" without preserve_minmax is a plain (mean-equivalent) rep.
+            SegmentConfig(n_segments=4, representation=Distribution(scope="local"))
+
+    def test_deprecated_cluster_alias_also_warns_on_segment(self):
+        # "cluster" normalizes to "local" (DeprecationWarning), then the segment
+        # preserve_minmax no-op warning fires too.
+        with pytest.warns((DeprecationWarning, UserWarning)):
+            SegmentConfig(
+                n_segments=4,
+                representation=Distribution(scope="cluster", preserve_minmax=True),
+            )
+
+    def test_local_segment_is_mean(self):
+        """scope="local" segment representation is equivalent to "mean" (#382)."""
+        pd.testing.assert_frame_equal(
+            self._reconstructed(Distribution(scope="local")),
+            self._reconstructed("mean"),
+        )
+
+    def test_local_minmax_segment_is_mean(self):
+        """preserve_minmax is a silent no-op for a scope="local" segment (#378)."""
+        pd.testing.assert_frame_equal(
+            self._reconstructed(Distribution(scope="local", preserve_minmax=True)),
+            self._reconstructed("mean"),
+        )
+
+    def test_global_segment_differs_from_mean(self):
+        """scope="global" is the only Distribution segment option distinct from mean."""
+        assert not self._reconstructed(Distribution(scope="global")).equals(
+            self._reconstructed("mean")
+        )

--- a/test/test_distribution_scope.py
+++ b/test/test_distribution_scope.py
@@ -1,0 +1,76 @@
+"""Tests for the ``Distribution.scope`` rename ("cluster" -> "local").
+
+``scope="cluster"`` was renamed to ``scope="local"`` because "cluster" is
+misleading for segment representations, where the group whose distribution is
+preserved is a segment, not a cluster. ``"cluster"`` remains accepted as a
+deprecated, behaviourally-identical alias.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from conftest import TESTDATA_CSV
+from tsam import ClusterConfig, Distribution, aggregate
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:KMeans is known to have a memory leak on Windows with MKL.*:UserWarning"
+    ),
+]
+
+
+def test_default_scope_is_local():
+    assert Distribution().scope == "local"
+
+
+def test_local_and_global_do_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert Distribution(scope="local").scope == "local"
+        assert Distribution(scope="global").scope == "global"
+
+
+def test_cluster_alias_warns_and_normalizes_to_local():
+    with pytest.warns(DeprecationWarning, match='scope="cluster" is deprecated'):
+        dist = Distribution(scope="cluster")
+    assert dist.scope == "local"
+
+
+def test_to_dict_omits_default_and_normalized_scope():
+    # "local" is the default, so it is omitted from the serialized form.
+    assert "scope" not in Distribution(scope="local").to_dict()
+    with pytest.warns(DeprecationWarning):
+        assert "scope" not in Distribution(scope="cluster").to_dict()
+    # "global" is non-default and is serialized.
+    assert Distribution(scope="global").to_dict()["scope"] == "global"
+
+
+def test_from_dict_accepts_deprecated_and_missing_scope():
+    assert Distribution.from_dict({}).scope == "local"
+    assert Distribution.from_dict({"scope": "global"}).scope == "global"
+    with pytest.warns(DeprecationWarning):
+        assert Distribution.from_dict({"scope": "cluster"}).scope == "local"
+
+
+def test_cluster_alias_is_behaviourally_identical_to_local():
+    """The deprecated alias must produce bit-for-bit identical aggregation output."""
+    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+    def run(scope):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return aggregate(
+                raw,
+                n_clusters=8,
+                period_duration=24,
+                cluster=ClusterConfig(
+                    method="hierarchical",
+                    use_duration_curves=False,
+                    representation=Distribution(scope=scope),
+                ),
+                preserve_column_means=False,
+            ).reconstructed
+
+    pd.testing.assert_frame_equal(run("cluster"), run("local"))


### PR DESCRIPTION
I stumbled across this while doing #376 and #377.
Distribution with its current scope is very confusing, because a `scope="cluster"` does not scope to cluster ehwn passed to SegmentConfig. The scope is **relative**!
This rename corrects that.

#376 also surfaces that Distribution with `scope='local'` is the same as "mean", just obscured and computationally more expensive. This warns now!

---
AI created content below

Stacked on #376 (integral/min-max fix), because the segment behaviours documented here are only correct with that fix underneath. Supersedes #381 (the standalone rename).

Covers the whole `Distribution` × segment corner in one coherent, verified change.

## 1. Rename `scope="cluster"` → `scope="local"` (backwards compatible)

`"cluster"` is misleading for **segment** representations, where the group whose distribution is preserved is a *segment*, not a cluster. The knob is stage-neutral:
- **`"local"`** — preserve each *group's own* distribution (a cluster of periods for a cluster rep; a segment of timesteps for a segment rep).
- **`"global"`** — preserve only the *enclosing whole's* distribution.

`"cluster"` stays accepted as a **deprecated alias**, normalized to `"local"` in `Distribution.__post_init__` with a **`FutureWarning`** (shown to end users by default, and matching the repo's existing user-facing deprecation convention — `plot.cluster_weights`). A behavioural-equivalence test asserts the alias yields bit-for-bit identical aggregation output.

## 2. Clarify segment semantics (#378, #382)

A segment collapses each attribute to a **single value**, so most `Distribution` options degenerate. Verified on #376's fixed code:

```
max|local          - mean| = 1.1e-13   # identical
max|local + minmax - mean| = 1.1e-13   # identical (preserve_minmax is a no-op)
max|global         - mean| = 39.5      # the only distinct option
```

- **#382**: `scope="local"` segment representation **is** `"mean"`. Documented in `SegmentConfig`; `scope="global"` is the only variant that differs.
- **#378**: `preserve_minmax=True` on a `scope="local"` segment is a silent no-op (one value cannot carry both min and max → T<3 guard keeps the mean). `SegmentConfig.__post_init__` now emits a **`UserWarning`** pointing at `scope="global"`. (`UserWarning`, not `FutureWarning`: it flags a current no-op, not a future behaviour change.)

## Docs

The v4 migration guide documents both: the `scope="cluster"` → `"local"` deprecation (under *Newly deprecated*) and the segment `preserve_minmax` warning (under *Integral and min/max preservation*).

## Test plan
- [x] `test/test_distribution_scope.py` — `TestScopeRename` (default/alias/warn/normalize, `to_dict`/`from_dict`, behavioural equivalence) and `TestSegmentDistribution` (warning fires only for local+minmax; local & local+minmax == mean; global differs).
- [x] Full suite: 427 passed, 112 skipped, 1 xpassed.
- [x] pre-commit (ruff, ruff-format, mypy, API-ref) green.

Closes #382. Addresses #378 (warning). Base #376 must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
