### PR TITLE
docs: normalize PR #383 docstrings to Google style (#339)

### DIFF
--- a/src/tsam/algorithms/duration_representation.py
+++ b/src/tsam/algorithms/duration_representation.py
@@ -1,4 +1,4 @@
-"""Orders a set of representation values to fit several candidate value sets"""
+"""Orders a set of representation values to fit several candidate value sets."""
 
 from __future__ import annotations
 

--- a/src/tsam/algorithms/representations.py
+++ b/src/tsam/algorithms/representations.py
@@ -25,37 +25,31 @@ def representations(
     ``MinMaxMean`` object — returning one representative period per cluster, in
     cluster order.
 
-    Parameters
-    ----------
-    candidates
-        Candidate matrix of period profiles, one row per original period.
-    cluster_order
-        Cluster label assigned to each period.
-    default
-        Representation used when ``representation_method`` is ``None``.
-    representation_method
-        Representation to apply; ``None`` falls back to ``default``.
-    representation_dict
-        Per-column method overrides for the min/max/mean representation.
-    distribution_period_wise
-        For the distribution representation, preserve the per-cluster duration
-        curve (``True``) or the global one (``False``).
-    n_timesteps_per_period
-        Timesteps per period; required by the distribution and min/max/mean
-        representations.
+    Args:
+        candidates: Candidate matrix of period profiles, one row per original
+            period.
+        cluster_order: Cluster label assigned to each period.
+        default: Representation used when ``representation_method`` is ``None``.
+        representation_method: Representation to apply; ``None`` falls back to
+            ``default``.
+        representation_dict: Per-column method overrides for the min/max/mean
+            representation.
+        distribution_period_wise: For the distribution representation, preserve
+            the per-cluster duration curve (``True``) or the global one
+            (``False``).
+        n_timesteps_per_period: Timesteps per period; required by the
+            distribution and min/max/mean representations.
 
-    Returns
-    -------
-    cluster_centers
-        Representative profile for each cluster, in cluster order.
-    cluster_center_indices
-        For medoid/maxoid, the index of the original period chosen as each
-        representative; ``None`` for the other methods.
+    Returns:
+        A tuple ``(cluster_centers, cluster_center_indices)`` where
+        ``cluster_centers`` is the representative profile for each cluster, in
+        cluster order, and ``cluster_center_indices`` is, for medoid/maxoid, the
+        index of the original period chosen as each representative; ``None`` for
+        the other methods.
 
-    See Also
-    --------
-    mean_representation, medoid_representation, maxoid_representation,
-    minmax_mean_representation
+    Note:
+        Related helpers: mean_representation, medoid_representation,
+        maxoid_representation, minmax_mean_representation.
     """
     cluster_center_indices = None
     if representation_method is None:
@@ -128,9 +122,10 @@ def maxoid_representation(
     candidates: np.ndarray,
     cluster_order: np.ndarray,
 ) -> tuple[list[np.ndarray], list[int]]:
-    """
-    Represents the candidates of a given cluster group (cluster_order)
-    by its maxoid, measured with the euclidean distance.
+    """Represent each cluster group by its maxoid (Euclidean distance).
+
+    Selects, for each cluster in ``cluster_order``, the candidate farthest from
+    the points of the other clusters.
     """
     # set cluster member that is farthest away from the points of the other clusters as maxoid
     cluster_centers = []
@@ -149,10 +144,7 @@ def medoid_representation(
     candidates: np.ndarray,
     cluster_order: np.ndarray,
 ) -> tuple[list[np.ndarray], list[int]]:
-    """
-    Represents the candidates of a given cluster group (cluster_order)
-    by its medoid, measured with the euclidean distance.
-    """
+    """Represent each cluster group by its medoid (Euclidean distance)."""
     # set cluster center as medoid
     cluster_centers = []
     cluster_center_indices = []
@@ -170,10 +162,7 @@ def mean_representation(
     candidates: np.ndarray,
     cluster_order: np.ndarray,
 ) -> list[np.ndarray]:
-    """
-    Represents the candidates of a given cluster group (cluster_order)
-    by its mean.
-    """
+    """Represent each cluster group by its mean."""
     # set cluster centers as means of the group candidates
     cluster_centers = []
     for cluster_num in np.unique(cluster_order):
@@ -189,10 +178,11 @@ def minmax_mean_representation(
     representation_dict: dict[str, str],
     n_timesteps_per_period: int,
 ) -> list[np.ndarray]:
-    """
-    Represents the candidates of a given cluster group (cluster_order)
-    by either the minimum, the maximum or the mean values of each time step for
-    all periods in that cluster depending on the command for each attribute.
+    """Represent each cluster group by per-timestep min, max, or mean values.
+
+    For each attribute (column), uses the minimum, maximum, or mean value of
+    each time step across all periods in the cluster, chosen per attribute by
+    ``representation_dict``.
     """
     cluster_centers = []
     rep_values = list(representation_dict.values())

--- a/src/tsam/commons.py
+++ b/src/tsam/commons.py
@@ -39,11 +39,19 @@ def time_index_from_dict(
 def parse_duration_hours(value: int | float | str, param_name: str) -> float:
     """Parse a duration value to hours.
 
-    Accepts:
-    - int/float: interpreted as hours (e.g., 24 -> 24.0 hours)
-    - str: pandas Timedelta string (e.g., '24h', '1d', '15min')
+    Accepts an int/float, interpreted as hours (e.g. 24 -> 24.0 hours), or a
+    string in pandas Timedelta format (e.g. '24h', '1d', '15min').
 
-    Returns duration in hours as float.
+    Args:
+        value: Duration as a number of hours or a pandas Timedelta string.
+        param_name: Name of the parameter, used in error messages.
+
+    Returns:
+        The duration in hours.
+
+    Raises:
+        ValueError: If value is a string that cannot be parsed as a duration.
+        TypeError: If value is not an int, float, or string.
     """
     if isinstance(value, (int, float)):
         return float(value)
@@ -66,18 +74,13 @@ def weighted_mean(
 ) -> float:
     """Weighted arithmetic mean of per-column values.
 
-    Parameters
-    ----------
-    per_column : pd.Series
-        One value per column (e.g. per-column MAE).
-    weights : dict or None
-        Column name → weight. Missing columns default to 1.
-        ``None`` is equivalent to uniform weights.
+    Args:
+        per_column: One value per column (e.g. per-column MAE).
+        weights: Column name to weight mapping. Missing columns default to 1.
+            None is equivalent to uniform weights.
 
-    Returns
-    -------
-    float
-        ``sum(value_i * w_i) / sum(w_i)``
+    Returns:
+        ``sum(value_i * w_i) / sum(w_i)``.
     """
     if weights:
         w = pd.Series(weights).reindex(per_column.index, fill_value=1.0)
@@ -95,18 +98,13 @@ def weighted_rms(
     the RMSE you would obtain by pooling all (weighted) residuals into
     a single series.
 
-    Parameters
-    ----------
-    per_column : pd.Series
-        One RMSE value per column.
-    weights : dict or None
-        Column name → weight. Missing columns default to 1.
-        ``None`` is equivalent to uniform weights.
+    Args:
+        per_column: One RMSE value per column.
+        weights: Column name to weight mapping. Missing columns default to 1.
+            None is equivalent to uniform weights.
 
-    Returns
-    -------
-    float
-        ``sqrt(sum(value_i² * w_i) / sum(w_i))``
+    Returns:
+        ``sqrt(sum(value_i² * w_i) / sum(w_i))``.
     """
     squared = per_column**2
     if weights:
@@ -135,30 +133,23 @@ def bounded_water_fill(
     element stays inside ``[lower, upper]``. This preserves the integral without
     flattening the distribution against either bound.
 
-    Parameters
-    ----------
-    values : np.ndarray
-        Starting values (any shape). Not mutated; a clipped copy is returned.
-    weights : np.ndarray
-        Per-element weights, broadcastable against ``values`` (e.g. one weight
-        per period, shape ``(n_periods, 1)``).
-    lower, upper : float
-        Inclusive bounds enforced on every element.
-    target_weighted_sum : float
-        Desired value of ``sum(weights * values)``.
-    rel_tolerance : float
-        Relative convergence tolerance; the absolute tolerance on the
-        weighted-sum residual is ``max(abs(target_weighted_sum), 1) *
-        rel_tolerance``.
-    max_passes : int
-        Safety cap on redistribution passes.
+    Args:
+        values: Starting values (any shape). Not mutated; a clipped copy is
+            returned.
+        weights: Per-element weights, broadcastable against ``values`` (e.g. one
+            weight per period, shape ``(n_periods, 1)``).
+        lower: Inclusive lower bound enforced on every element.
+        upper: Inclusive upper bound enforced on every element.
+        target_weighted_sum: Desired value of ``sum(weights * values)``.
+        rel_tolerance: Relative convergence tolerance; the absolute tolerance on
+            the weighted-sum residual is
+            ``max(abs(target_weighted_sum), 1) * rel_tolerance``.
+        max_passes: Safety cap on redistribution passes.
 
-    Returns
-    -------
-    tuple[np.ndarray, bool, int]
-        The adjusted array, whether the target was reached within tolerance
-        (``False`` if the passes were exhausted or no feasible room remained),
-        and the number of redistribution passes performed.
+    Returns:
+        A tuple of the adjusted array, whether the target was reached within
+        tolerance (False if the passes were exhausted or no feasible room
+        remained), and the number of redistribution passes performed.
     """
     tolerance = max(abs(target_weighted_sum), 1.0) * rel_tolerance
     adjusted = np.clip(np.array(values, dtype=float), lower, upper)

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -42,56 +42,52 @@ Solver = Literal["highs", "cbc", "gurobi", "cplex"]
 class Distribution:
     """Representation that preserves the value distribution (duration curve).
 
-    Parameters
-    ----------
-    scope : "local" or "global", default "local"
-        "local": preserve each group's own distribution separately. The group is
-        a cluster of periods for a cluster representation, or a segment of
-        timesteps for a segment representation.
-        "global": preserve only the distribution of the enclosing whole (the
-        full time series for a cluster representation, a single period for a
-        segment representation).
+    Args:
+        scope: "local" preserves each group's own distribution separately. The
+            group is a cluster of periods for a cluster representation, or a
+            segment of timesteps for a segment representation. "global"
+            preserves only the distribution of the enclosing whole (the full
+            time series for a cluster representation, a single period for a
+            segment representation). "cluster" is accepted as a deprecated alias
+            for "local" (the old name, which was misleading for segment
+            representations where the group is a segment, not a cluster).
+        preserve_minmax: If True, also preserves min/max values per timestep
+            (equivalent to old "distribution_minmax").
+        reference_attribute: Name of a data column. If given, a single temporal
+            ordering derived from this attribute is applied to all attributes,
+            preserving their concurrency (co-incidence in time) with the
+            reference attribute while each attribute still fits its own
+            distribution. Only valid with ``scope="local"``. Equivalent to
+            ``concurrency="reference"``.
+        concurrency: Strategy used to derive the synthetic time axis, one of
+            ``"independent"``, ``"reference"``, ``"medoid"``, ``"consensus"``,
+            ``"assignment"``. All strategies preserve every attribute's marginal
+            distribution and differ only in how the attributes' concurrency is
+            preserved:
 
-        ``"cluster"`` is accepted as a deprecated alias for ``"local"`` (the old
-        name, which was misleading for segment representations where the group is
-        a segment, not a cluster).
-    preserve_minmax : bool, default False
-        If True, also preserves min/max values per timestep
-        (equivalent to old "distribution_minmax").
-    reference_attribute : str, optional
-        Name of a data column. If given, a single temporal ordering derived from
-        this attribute is applied to all attributes, preserving their
-        concurrency (co-incidence in time) with the reference attribute while
-        each attribute still fits its own distribution. Only valid with
-        ``scope="local"``. Equivalent to ``concurrency="reference"``.
-    concurrency : {"independent", "reference", "medoid", "consensus", \
-"assignment"}, optional
-        Strategy used to derive the synthetic time axis. All strategies preserve
-        every attribute's marginal distribution and differ only in how the
-        attributes' concurrency is preserved:
+            - ``"independent"`` (default): each attribute ordered by its own mean
+              profile — best marginal fit, concurrency across attributes lost.
+            - ``"reference"``: single ordering from ``reference_attribute``.
+            - ``"medoid"``: each attribute ordered by the cluster medoid's ranks,
+              reproducing a real period's joint co-occurrence.
+            - ``"consensus"``: single ordering from the first principal component
+              of all attributes' mean profiles.
+            - ``"assignment"``: optimal single ordering minimising total
+              deviation from the cluster mean profile across all attributes.
 
-        - ``"independent"`` (default): each attribute ordered by its own mean
-          profile — best marginal fit, concurrency across attributes lost.
-        - ``"reference"``: single ordering from ``reference_attribute``.
-        - ``"medoid"``: each attribute ordered by the cluster medoid's ranks,
-          reproducing a real period's joint co-occurrence.
-        - ``"consensus"``: single ordering from the first principal component of
-          all attributes' mean profiles.
-        - ``"assignment"``: optimal single ordering minimising total deviation
-          from the cluster mean profile across all attributes.
+            Only valid with ``scope="local"``. If None, resolves to
+            ``"reference"`` when ``reference_attribute`` is given, otherwise
+            ``"independent"``.
 
-        Only valid with ``scope="local"``. If None, resolves to ``"reference"``
-        when ``reference_attribute`` is given, otherwise ``"independent"``.
-
-    Notes
-    -----
-    When used as a segment representation (``SegmentConfig.representation``),
-    each segment is a single value per attribute, which constrains two options:
-    ``preserve_minmax`` only takes effect with ``scope="global"`` (a single
-    value cannot carry both min and max, so ``scope="local"`` keeps the
-    integral-preserving mean), and ``concurrency`` / ``reference_attribute`` are
-    not supported (there is no within-period time axis left to order — set them
-    on the cluster representation, where ordering runs before segmentation).
+    Note:
+        When used as a segment representation (``SegmentConfig.representation``),
+        each segment is a single value per attribute, which constrains two
+        options: ``preserve_minmax`` only takes effect with ``scope="global"``
+        (a single value cannot carry both min and max, so ``scope="local"``
+        keeps the integral-preserving mean), and ``concurrency`` /
+        ``reference_attribute`` are not supported (there is no within-period time
+        axis left to order — set them on the cluster representation, where
+        ordering runs before segmentation).
     """
 
     # "cluster" is a deprecated alias for "local"; normalized in __post_init__.
@@ -159,12 +155,11 @@ class MinMaxMean:
 
     Columns not listed in max_columns or min_columns default to mean.
 
-    Parameters
-    ----------
-    max_columns : list[str]
-        Columns represented by their maximum value across cluster members.
-    min_columns : list[str]
-        Columns represented by their minimum value across cluster members.
+    Args:
+        max_columns: Columns represented by their maximum value across cluster
+            members.
+        min_columns: Columns represented by their minimum value across cluster
+            members.
     """
 
     max_columns: list[str] = field(default_factory=list)
@@ -215,59 +210,48 @@ def representation_from_dict(data: str | dict) -> Representation:
 class ClusterConfig:
     """Configuration for the clustering algorithm.
 
-    Parameters
-    ----------
-    method : str, default "hierarchical"
-        Clustering algorithm to use:
-        - "averaging": Sequential averaging of periods
-        - "kmeans": K-means clustering (fast, uses centroids)
-        - "kmedoids": K-medoids using MILP optimization (uses actual periods)
-        - "kmaxoids": K-maxoids (selects most dissimilar periods)
-        - "hierarchical": Agglomerative hierarchical clustering
-        - "contiguous": Hierarchical with temporal contiguity constraint
+    Args:
+        method: Clustering algorithm to use:
+            - "averaging": Sequential averaging of periods
+            - "kmeans": K-means clustering (fast, uses centroids)
+            - "kmedoids": K-medoids using MILP optimization (uses actual periods)
+            - "kmaxoids": K-maxoids (selects most dissimilar periods)
+            - "hierarchical": Agglomerative hierarchical clustering
+            - "contiguous": Hierarchical with temporal contiguity constraint
+        representation: How to represent cluster centers. Accepts either a
+            string shortcut or a typed representation object for additional
+            options.
 
-    representation : str, Distribution, or MinMaxMean, optional
-        How to represent cluster centers. Accepts either a string shortcut
-        or a typed representation object for additional options:
+            String shortcuts:
+            - "mean": Centroid (average of cluster members)
+            - "medoid": Actual period closest to centroid
+            - "maxoid": Actual period most dissimilar to others
+            - "distribution": Preserve value distribution (duration curve)
+            - "distribution_minmax": Distribution + preserve min/max values
+            - "minmax_mean": Combine min/max/mean per timestep
 
-        String shortcuts:
-        - "mean": Centroid (average of cluster members)
-        - "medoid": Actual period closest to centroid
-        - "maxoid": Actual period most dissimilar to others
-        - "distribution": Preserve value distribution (duration curve)
-        - "distribution_minmax": Distribution + preserve min/max values
-        - "minmax_mean": Combine min/max/mean per timestep
+            Typed objects (for additional options):
+            - ``Distribution(scope="local"|"global", preserve_minmax=False)``:
+              Preserve value distribution. ``scope`` controls whether each
+              cluster's distribution is preserved separately ("local") or
+              only the overall time series distribution ("global"). ``"cluster"``
+              is a deprecated alias for ``"local"``.
+            - ``MinMaxMean(max_columns=[...], min_columns=[...])``:
+              Combine min/max/mean per column. Columns not listed default to mean.
 
-        Typed objects (for additional options):
-        - ``Distribution(scope="local"|"global", preserve_minmax=False)``:
-          Preserve value distribution. ``scope`` controls whether each
-          cluster's distribution is preserved separately ("local") or
-          only the overall time series distribution ("global"). ``"cluster"``
-          is a deprecated alias for ``"local"``.
-        - ``MinMaxMean(max_columns=[...], min_columns=[...])``:
-          Combine min/max/mean per column. Columns not listed default to mean.
-
-        Default depends on method:
-        - "mean" for averaging, kmeans
-        - "medoid" for kmedoids, hierarchical, contiguous
-        - "maxoid" for kmaxoids
-
-    scale_by_column_means : bool, default False
-        Divide each column by its mean after MinMax normalization, so all
-        columns have equal mean before clustering.
-        Useful when columns have very different scales.
-
-    use_duration_curves : bool, default False
-        Sort values within each period before clustering.
-        Matches periods by their value distribution rather than timing.
-
-    include_period_sums : bool, default False
-        Include period totals as additional features for clustering.
-        Helps preserve total energy/load values.
-
-    solver : str, default "highs"
-        MILP solver for kmedoids method.
-        Options: "highs" (default, open source), "cbc", "gurobi", "cplex"
+            Default depends on method:
+            - "mean" for averaging, kmeans
+            - "medoid" for kmedoids, hierarchical, contiguous
+            - "maxoid" for kmaxoids
+        scale_by_column_means: Divide each column by its mean after MinMax
+            normalization, so all columns have equal mean before clustering.
+            Useful when columns have very different scales.
+        use_duration_curves: Sort values within each period before clustering.
+            Matches periods by their value distribution rather than timing.
+        include_period_sums: Include period totals as additional features for
+            clustering. Helps preserve total energy/load values.
+        solver: MILP solver for kmedoids method. Options: "highs" (open source),
+            "cbc", "gurobi", "cplex".
     """
 
     method: ClusterMethod
@@ -382,36 +366,30 @@ class SegmentConfig:
     Segmentation reduces the temporal resolution within each typical period,
     grouping consecutive timesteps into segments.
 
-    Parameters
-    ----------
-    n_segments : int
-        Number of segments per period.
-        Must be less than or equal to the number of timesteps per period.
-        Example: period_duration=24 with hourly data has 24 timesteps,
-        so n_segments could be 1-24.
+    Args:
+        n_segments: Number of segments per period. Must be less than or equal to
+            the number of timesteps per period. Example: period_duration=24 with
+            hourly data has 24 timesteps, so n_segments could be 1-24.
+        representation: How to represent each segment:
+            - "mean": Average value of timesteps in segment
+            - "medoid": Actual timestep closest to segment mean
+            - "distribution": Preserve distribution within segment
+            - ``Distribution(...)``: Distribution with additional options (see Note)
+            - ``MinMaxMean(...)``: Per-column min/max/mean
 
-    representation : str, Distribution, or MinMaxMean, default "mean"
-        How to represent each segment:
-        - "mean": Average value of timesteps in segment
-        - "medoid": Actual timestep closest to segment mean
-        - "distribution": Preserve distribution within segment
-        - ``Distribution(...)``: Distribution with additional options (see Notes)
-        - ``MinMaxMean(...)``: Per-column min/max/mean
+    Note:
+        A segment collapses each attribute to a **single value**, so the
+        ``Distribution`` options behave differently than for a cluster
+        representation:
 
-    Notes
-    -----
-    A segment collapses each attribute to a **single value**, so the
-    ``Distribution`` options behave differently than for a cluster
-    representation:
-
-    - ``scope="local"`` (the default) is equivalent to ``"mean"`` — each
-      segment's single value is the mean of its timesteps. Only
-      ``scope="global"`` produces a distinct result (it matches the whole
-      period's value distribution rather than each segment's mean).
-    - ``preserve_minmax`` only takes effect with ``scope="global"``; a single
-      value cannot carry both the min and the max, so with ``scope="local"`` it
-      is silently ignored and the integral-preserving mean is kept (a
-      ``UserWarning`` is emitted).
+        - ``scope="local"`` (the default) is equivalent to ``"mean"`` — each
+          segment's single value is the mean of its timesteps. Only
+          ``scope="global"`` produces a distinct result (it matches the whole
+          period's value distribution rather than each segment's mean).
+        - ``preserve_minmax`` only takes effect with ``scope="global"``; a
+          single value cannot carry both the min and the max, so with
+          ``scope="local"`` it is silently ignored and the integral-preserving
+          mean is kept (a ``UserWarning`` is emitted).
     """
 
     n_segments: int
@@ -461,30 +439,20 @@ class ExtremeConfig:
     Extreme periods contain critical peak values that must be preserved
     in the aggregated representation (e.g., peak demand for capacity sizing).
 
-    Parameters
-    ----------
-    method : str, default "append"
-        How to handle extreme periods:
-        - "append": Add extreme periods as additional cluster centers
-        - "replace": Replace the nearest cluster center with the extreme
-        - "new_cluster": Add as new cluster and reassign affected periods
-
-    max_value : list[str], optional
-        Column names where the maximum value should be preserved.
-        The entire period containing that single extreme value becomes an extreme period.
-        Example: ["electricity_demand"] to preserve peak demand hour.
-
-    min_value : list[str], optional
-        Column names where the minimum value should be preserved.
-        Example: ["temperature"] to preserve coldest hour.
-
-    max_period : list[str], optional
-        Column names where the period with maximum total should be preserved.
-        Example: ["solar_generation"] to preserve highest solar day.
-
-    min_period : list[str], optional
-        Column names where the period with minimum total should be preserved.
-        Example: ["wind_generation"] to preserve lowest wind day.
+    Args:
+        method: How to handle extreme periods:
+            - "append": Add extreme periods as additional cluster centers
+            - "replace": Replace the nearest cluster center with the extreme
+            - "new_cluster": Add as new cluster and reassign affected periods
+        max_value: Column names where the maximum value should be preserved. The
+            entire period containing that single extreme value becomes an extreme
+            period. Example: ["electricity_demand"] to preserve peak demand hour.
+        min_value: Column names where the minimum value should be preserved.
+            Example: ["temperature"] to preserve coldest hour.
+        max_period: Column names where the period with maximum total should be
+            preserved. Example: ["solar_generation"] to preserve highest solar day.
+        min_period: Column names where the period with minimum total should be
+            preserved. Example: ["wind_generation"] to preserve lowest wind day.
     """
 
     method: ExtremeMethod = "append"

--- a/src/tsam/options.py
+++ b/src/tsam/options.py
@@ -8,13 +8,12 @@ class Options:
 
     Access and modify via the module-level ``tsam.options`` instance.
 
-    Examples
-    --------
-    >>> import tsam
-    >>> tsam.options.rescale_max_iterations = 50
-    >>> tsam.options.rescale_tolerance = 1e-8
-    >>> tsam.options.min_weight = 1e-4
-    >>> tsam.options.reset()  # restore defaults
+    Examples:
+        >>> import tsam
+        >>> tsam.options.rescale_max_iterations = 50
+        >>> tsam.options.rescale_tolerance = 1e-8
+        >>> tsam.options.min_weight = 1e-4
+        >>> tsam.options.reset()  # restore defaults
     """
 
     def __init__(self) -> None:

--- a/src/tsam/pipeline/rescale.py
+++ b/src/tsam/pipeline/rescale.py
@@ -41,35 +41,29 @@ def rescale_representatives(
     values are preserved. Columns in ``exclude_columns`` are also skipped —
     useful for binary 0/1 columns that should not be scaled.
 
-    Parameters
-    ----------
-    cluster_periods
-        Unweighted cluster representatives to rescale.
-    cluster_period_no_occur
-        Occurrence count per cluster (the rescaling weights).
-    extreme_cluster_idx
-        Indices of extreme clusters to leave untouched.
-    profiles_df
-        Normalized period profiles, source of the target column means.
-    original_data
-        Original input, defining the column order and totals to match.
-    normalize_column_means
-        Whether column-mean normalization was applied (sets the clip bound).
-    n_timesteps_per_period
-        Timesteps per period, used to reshape the representatives.
-    exclude_columns
-        Columns to skip during rescaling.
+    Args:
+        cluster_periods: Unweighted cluster representatives to rescale.
+        cluster_period_no_occur: Occurrence count per cluster (the rescaling
+            weights).
+        extreme_cluster_idx: Indices of extreme clusters to leave untouched.
+        profiles_df: Normalized period profiles, source of the target column
+            means.
+        original_data: Original input, defining the column order and totals to
+            match.
+        normalize_column_means: Whether column-mean normalization was applied
+            (sets the clip bound).
+        n_timesteps_per_period: Timesteps per period, used to reshape the
+            representatives.
+        exclude_columns: Columns to skip during rescaling.
 
-    Returns
-    -------
-    tuple[np.ndarray, dict]
-        ``(rescaled_periods, deviations_dict)`` — the corrected representatives
-        and per-column residual deviations after rescaling.
+    Returns:
+        A tuple ``(rescaled_periods, deviations_dict)`` — the corrected
+        representatives and per-column residual deviations after rescaling.
 
-    See Also
-    --------
-    cluster_periods : Produces the representatives rescaled here.
-    add_extreme_periods : Its extreme clusters are excluded from rescaling.
+    Note:
+        ``cluster_periods`` produces the representatives rescaled here, and the
+        extreme clusters from ``add_extreme_periods`` are excluded from
+        rescaling.
     """
     columns = list(original_data.columns)
 


### PR DESCRIPTION
Stacked on #383. Follow-up to the #339 docstring normalization: brings the docstrings that #383 adds or changes into the same Google-style convention, so the two land consistently.

**Docstring-only** — the AST of every touched file is identical to #383 aside from docstrings; ruff, ruff-format, and mypy pass.

### Files (6)
- `config.py` — `Distribution` / `MinMaxMean` / `ClusterConfig` / `SegmentConfig` / `ExtremeConfig` NumPy blocks → Google `Args:` / `Note:`. Kept the `scope="cluster"` deprecated-alias notes and the conditional `representation` default.
- `commons.py` — `bounded_water_fill` + `weighted_mean` / `weighted_rms` / `parse_duration_hours`.
- `options.py` — `Examples` block; **kept** `(default: N)` on the settings properties (set in `__init__`, not visible in the property signature).
- `algorithms/duration_representation.py`, `algorithms/representations.py`, `pipeline/rescale.py` — NumPy / `See Also` → Google `Args:` / `Returns:` / `Note:`.

### Convention (per #339)
- Google style; no types in docstrings (rely on annotations); no defaults already visible in the signature.
- `Args:` for user-instantiated config classes; `Attributes:` for result/stat carriers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)