### PR TITLE
chore: gitignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ trash/
 docs/notebooks/results/
 docs/notebooks/clustering.json
 .cache/
+
+# uv resolves this on demand; do not track it
+uv.lock


### PR DESCRIPTION
Adds `uv.lock` to `.gitignore` so it is never accidentally committed — uv resolves dependencies on demand and the lock file should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)