### PR TITLE
fix(docs): disable navigation.instant so notebook plots render

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,9 +13,6 @@ theme:
     text: Roboto
     code: Roboto Mono
   features:
-    - navigation.instant
-    - navigation.instant.prefetch
-    - navigation.instant.progress
     - navigation.tabs
     - navigation.sections
     - navigation.indexes


### PR DESCRIPTION
## Problem

Notebook plots render blank on the docs site unless a page is hard-refreshed. Navigating via the sidebar shows the figure containers empty.

## Cause

- mkdocs-material's `navigation.instant` swaps page content in-place without re-executing `<script>` tags.
- Plotly 6.x's `notebook_connected` renderer (set in every example notebook's setup cell) emits a `<script type="module">import "https://cdn.plot.ly/…"</script>`. After an instant content swap that module script never runs, so the figure never initialises.
- Result: plots appear only on a full page load, not on instant navigation.

## Fix

Drop the three `navigation.instant*` theme features so every navigation is a full page load. The module scripts then execute normally and all notebook figures render.

## Alternatives considered

- **`iframe`/`iframe_connected` renderer** (what `scripts/execute_notebooks.py` intends via `PLOTLY_RENDERER`): overridden by each notebook's explicit `pio.renderers.default = "notebook_connected"`, and it writes per-figure `iframe_figures/*.html` files whose relative paths don't line up with mkdocs-jupyter's per-notebook page URLs — fragile.
- Keeping instant nav and hardcoding a self-contained renderer would inline full plotly.js per notebook (multi-MB pages).

Disabling instant nav is the smallest reliable change.

## Testing

Built locally with `mkdocs serve` (notebooks pre-executed via `scripts/execute_notebooks.py`); figures across `visualization`, `quickstart`, `building_energy_system`, etc. render on normal sidebar navigation.