### PR TITLE
chore: fix pre-commit hygiene flagged by CI on develop-v4

### DIFF
--- a/docs/assets/architecture/context_diagram.d2
+++ b/docs/assets/architecture/context_diagram.d2
@@ -12,20 +12,20 @@ vertical-gap: 100
 horizontal-gap: 200
 
 
-user: "Energy-system modeler\nor data scientist" 
+user: "Energy-system modeler\nor data scientist"
 user.shape: person
 
 
-downstream: "Downstream frameworks\nETHOS.FINE / flixopt / oemof" 
+downstream: "Downstream frameworks\nETHOS.FINE / flixopt / oemof"
 
 user -> downstream: "feeds typical periods\ninto optimization model"
 
 TSAM and Integrated Software: {
-    grid-rows: 2 
+    grid-rows: 2
 
-tsam: "ETHOS.TSAM\nTime-series aggregation library" 
+tsam: "ETHOS.TSAM\nTime-series aggregation library"
 solver: "MILP solver\ne.g. HiGHS"
-solver -> tsam: "Only for the exact k medoids method"  
+solver -> tsam: "Only for the exact k medoids method"
 }
 
 # user -> TSAM and Integrated Software.tsam: "provides input time series\npd.DataFrame\nT rows × C cols"
@@ -34,4 +34,3 @@ solver -> tsam: "Only for the exact k medoids method"
 
 user -> TSAM and Integrated Software.tsam: Provide input time series\n and receive typical periods,\n cluster order, and\naccuracy metrics
 TSAM and Integrated Software.tsam -> user
-

--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -1,6 +1,6 @@
 # Background
 
-This section contains conceptual and design material about tsam — the *why* and *how* behind its mathematics, structure, and major decisions. 
+This section contains conceptual and design material about tsam — the *why* and *how* behind its mathematics, structure, and major decisions.
 
 | Section | Contents |
 |---------|----------|

--- a/scripts/execute_notebooks.py
+++ b/scripts/execute_notebooks.py
@@ -68,7 +68,7 @@ def execute_one(path: Path, timeout: int) -> Result:
     except CellExecutionError as exc:
         first_line = str(exc).splitlines()[0] if str(exc) else "CellExecutionError"
         return Result(path, time.perf_counter() - start, first_line)
-    except Exception as exc:  # noqa: BLE001 — surface anything as a failure
+    except Exception as exc:  # surface anything as a failure
         return Result(path, time.perf_counter() - start, f"{type(exc).__name__}: {exc}")
 
 


### PR DESCRIPTION
The `Pre-commit` CI job (`pre-commit run --all-files`) is red on develop-v4. Three trivial fixes:

- trailing whitespace: `docs/assets/architecture/context_diagram.d2`, `docs/background/index.md`
- missing final newline: `context_diagram.d2`
- unused `# noqa: BLE001` (RUF100) in `scripts/execute_notebooks.py` — rule isn't active; kept the intent as a plain comment

These slipped in via `--no-verify` merge commits (the de-conflict/topology work) and the newer ruff pin from the develop merge surfaced the noqa. Auto-fixed with the hooks. Unblocks the Pre-commit check on #234 and the other open v4 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)