### PR TITLE
docs: normalize docstrings to Google style (#339)

### DIFF
--- a/src/tsam/algorithms/k_maxoids.py
+++ b/src/tsam/algorithms/k_maxoids.py
@@ -19,8 +19,9 @@ class KMaxoids(BaseEstimator, ClusterMixin, TransformerMixin):
 
     Args:
         n_clusters: How many maxoids. Must be positive.
-        distance_metric: What distance metric to use. It can be either a self defined callable or s string supported by scikit-learn
-        such as.
+        distance_metric: What distance metric to use. It can be either a
+            self-defined callable or a string supported by scikit-learn,
+            such as ``"euclidean"``.
     """
 
     def __init__(

--- a/src/tsam/algorithms/segmentation.py
+++ b/src/tsam/algorithms/segmentation.py
@@ -59,16 +59,16 @@ def segmentation(
         segment_center_indices_list)`` where:
 
         - ``segmented_typical`` is a MultiIndex DataFrame similar to
-          ``normalized_typical_periods`` but with segments instead of time steps.
-          Moreover, two additional index levels define the length of each segment
-          and the time step index at which each segment starts.
-        - ``predicted_segmented`` is a MultiIndex DataFrame with the same shape as
-          ``normalized_typical_periods``, but with overwritten values derived from
-          segmentation used for prediction of the original periods and accuracy
-          indicators.
-        - ``segment_center_indices_list`` is a list of segment center indices per
-          typical period. Each entry is a list of indices indicating which
-          timestep is the representative for each segment.
+            ``normalized_typical_periods`` but with segments instead of time
+            steps. Moreover, two additional index levels define the length of
+            each segment and the time step index at which each segment starts.
+        - ``predicted_segmented`` is a MultiIndex DataFrame with the same shape
+            as ``normalized_typical_periods``, but with overwritten values
+            derived from segmentation used for prediction of the original
+            periods and accuracy indicators.
+        - ``segment_center_indices_list`` is a list of segment center indices
+            per typical period. Each entry is a list of indices indicating which
+            timestep is the representative for each segment.
     """
     # Initialize lists for predicted and segmented DataFrame
     segmented_list = []


### PR DESCRIPTION
## Summary

Merges the `v4/normalize-docstrings` work into `develop-v4`. This branch converts the `src/tsam` docstrings from reStructuredText (`:param:`/`:type:`) to Google style so they render cleanly under mkdocstrings/griffe, plus type-annotation and formatting follow-ups.

The top commit fixes the two docstrings that were breaking the **Build docs** CI job (`mkdocs build --strict`, where griffe warnings are fatal):

- **`algorithms/k_maxoids.py`** — the `distance_metric` description wrapped onto a line at argument-indent level, so griffe read it as a new argument and failed to parse a `name: description` pair (`Failed to get 'name: description' pair from 'such as.'`). Reindented as a continuation, fixed the `s string` typo, and completed the sentence.
- **`algorithms/segmentation.py`** — the `Returns:` bulleted list used a 2-space hanging indent, tripping griffe's `Confusing indentation for continuation line …` check (8 warnings). Reindented the continuation lines onto griffe's 4-space grid.

## Verification

`mkdocs build --strict` now completes with **0 griffe warnings** (`Documentation built in 32.22 seconds`), reproduced locally in the docs env. Previously it ended with `Aborted with 9 warnings in strict mode!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)