### PR TITLE
chore: fix pre-commit failure on develop-v4 (notebook nbstripout + EOF)

### DIFF
--- a/docs/tutorials/comparing_clustering_methods.ipynb
+++ b/docs/tutorials/comparing_clustering_methods.ipynb
@@ -393,11 +393,36 @@
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "source": "## 7  The other cost: runtime\n\nAccuracy is only half the decision. The six methods differ enormously in what they cost to\n*run* — and that gap, not fit, decides which ones you can still afford once a year of days replaces\ntwelve.\n\nYou might expect to settle it right here, by timing all six on these 12 days. **Don't** — it is the\none question these designed days cannot answer, and seeing why is the lesson. At 12 periods you\nmeasure fixed overhead, not the algorithms, and the ranking that overhead produces is not merely\nnoisy but *inverted*:\n\n* **`kmeans` looks slow** here, because scikit-learn restarts it ten times from different seeds and\n  that setup dwarfs the real work at this size. On a year of days it is one of the *fastest*.\n* **`kmedoids` looks cheap** here, and on a year of days it is the *slowest, by two orders of\n  magnitude* — it solves an exact MILP whose size grows with the **square** of the period count, so\n  it barely notices twelve periods and chokes on hundreds.\n\nThat is the exact trap a small-sample benchmark sets, sprung here on data built to make it obvious.\nAll these 12 days honestly tell you is the coarsest fact — the six are not interchangeable on cost,\nand the three cheap ones (`averaging`, `hierarchical`, `contiguous`) are cheap by a wide margin.\n\nFor runtimes you can carry away — measured across dataset sizes, with the crossover where the\nranking flips and the levers that move it — see\n**[How long will this take?](../how-to/runtime.ipynb)**."
+   "source": [
+    "## 7  The other cost: runtime\n",
+    "\n",
+    "Accuracy is only half the decision. The six methods differ enormously in what they cost to\n",
+    "*run* — and that gap, not fit, decides which ones you can still afford once a year of days replaces\n",
+    "twelve.\n",
+    "\n",
+    "You might expect to settle it right here, by timing all six on these 12 days. **Don't** — it is the\n",
+    "one question these designed days cannot answer, and seeing why is the lesson. At 12 periods you\n",
+    "measure fixed overhead, not the algorithms, and the ranking that overhead produces is not merely\n",
+    "noisy but *inverted*:\n",
+    "\n",
+    "* **`kmeans` looks slow** here, because scikit-learn restarts it ten times from different seeds and\n",
+    "  that setup dwarfs the real work at this size. On a year of days it is one of the *fastest*.\n",
+    "* **`kmedoids` looks cheap** here, and on a year of days it is the *slowest, by two orders of\n",
+    "  magnitude* — it solves an exact MILP whose size grows with the **square** of the period count, so\n",
+    "  it barely notices twelve periods and chokes on hundreds.\n",
+    "\n",
+    "That is the exact trap a small-sample benchmark sets, sprung here on data built to make it obvious.\n",
+    "All these 12 days honestly tell you is the coarsest fact — the six are not interchangeable on cost,\n",
+    "and the three cheap ones (`averaging`, `hierarchical`, `contiguous`) are cheap by a wide margin.\n",
+    "\n",
+    "For runtimes you can carry away — measured across dataset sizes, with the crossover where the\n",
+    "ranking flips and the levers that move it — see\n",
+    "**[How long will this take?](../how-to/runtime.ipynb)**."
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "source": [
     "## 8  Recap — which logic, when\n",


### PR DESCRIPTION
`CI (develop)` on `develop-v4` (umbrella #234) is failing at the **Pre-commit** job. Two hooks trip on a single file, `docs/tutorials/comparing_clustering_methods.ipynb`:

- **nbstripout** — un-stripped notebook output/metadata
- **end-of-file-fixer** — missing trailing newline

## Fix
Ran both hooks. The only substantive change is the last markdown cell's `source`, which was stored as one JSON string and is now normalized to the canonical array-of-lines form (same text, no content change); the cell `id` is reassigned by nbstripout and a trailing newline added. `pre-commit run --files <nb>` passes afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)