### PR TITLE
fix: restore v3 parity for period sums, and split cluster/segment representations

### DIFF
--- a/docs/migration/v3-to-v4.md
+++ b/docs/migration/v3-to-v4.md
@@ -100,6 +100,41 @@ rely on exact aggregated values with rescaling enabled, regenerate any pinned
 references. Aggregate metrics (integral, min/max envelope) are preserved or
 improved.
 
+## Cluster and segment representations are resolved independently
+
+`ClusterConfig.representation` and `SegmentConfig.representation` are two
+separate settings, but v3 resolved them into a **single** per-column
+`representationDict`, and the segment representation was applied last. Setting a
+`MinMaxMean` on `SegmentConfig` therefore silently overwrote the cluster
+representation's per-column assignment:
+
+```python
+tsam.aggregate(
+    data,
+    n_clusters=8,
+    cluster=ClusterConfig(representation=MinMaxMean(max_columns=["GHI"])),
+    segments=SegmentConfig(n_segments=6, representation=MinMaxMean(min_columns=["Load"])),
+)
+# v3: BOTH stages used {Load: min}; the cluster's {GHI: max} was discarded.
+# v4: the cluster stage uses {GHI: max}, the segment stage uses {Load: min}.
+```
+
+Each stage now builds its own dict from its own configuration.
+
+**What changes:**
+
+- Configurations that set a `MinMaxMean` (or a `Distribution` with per-column
+  effects) on **both** `ClusterConfig` and `SegmentConfig` now honour both.
+  Previously the cluster one was dropped, so cluster representatives change.
+- Configurations that set it on only one of the two are unaffected — this is the
+  overwhelming majority, and every golden regression case is bit-identical
+  except the one added to cover this.
+
+**Action required:** If you set a per-column representation on both
+`ClusterConfig` and `SegmentConfig`, your cluster representatives were
+previously computed with the *segment* column assignment. They are now computed
+with the one you asked for. Regenerate any pinned references.
+
 ## Removed deprecated APIs
 
 The v3 deprecation shims have been **removed** in v4:

--- a/src/tsam/pipeline/clustering.py
+++ b/src/tsam/pipeline/clustering.py
@@ -128,6 +128,7 @@ def cluster_periods(
 def cluster_sorted_periods(
     candidates: np.ndarray,
     n_columns: int,
+    n_timesteps_per_period: int,
     n_clusters: int,
     cluster: ClusterConfig,
 ) -> tuple[list[np.ndarray], list[int], np.ndarray]:
@@ -152,12 +153,25 @@ def cluster_sorted_periods(
     path where the configured representation is honoured.
 
     Args:
-        candidates: Candidate period matrix (possibly weighted).
+        candidates: Candidate period matrix (possibly weighted), laid out as
+            ``n_columns`` contiguous blocks of equal length. It must **not**
+            carry the period-sum features that `ClusterConfig.include_period_sums`
+            appends: those are not timesteps, so they would make the per-column
+            reshape below misread every block boundary. Period sums therefore
+            do not influence duration-curve clustering.
         n_columns: Number of original columns, needed to reshape per-column
             before sorting.
+        n_timesteps_per_period: Length of each column's block. Passed in rather
+            than derived as ``candidates.shape[1] // n_columns`` because that
+            division cannot tell a wider block from an extra block, and so
+            silently accepted the augmented matrix.
         n_clusters: Number of clusters to form.
         cluster: Clustering configuration; only ``method`` and ``solver`` are
             used here, for the reason given above.
+
+    Raises:
+        ValueError: If ``candidates`` does not split evenly into ``n_columns``
+            blocks of the same length.
 
     Returns:
         ``(cluster_centers, cluster_center_indices, cluster_order)``. The
@@ -172,9 +186,16 @@ def cluster_sorted_periods(
     # Use candidates (already weighted) so that clustering distance respects
     # column weights — matching v3 behaviour.
     n_periods, n_total = candidates.shape
-    n_timesteps = n_total // n_columns
+    expected = n_columns * n_timesteps_per_period
+    if n_total != expected:
+        raise ValueError(
+            f"cluster_sorted_periods expects {n_columns} blocks of "
+            f"{n_timesteps_per_period} timesteps ({expected} columns), but the "
+            f"candidate matrix is {n_total} wide. Any appended period-sum "
+            "features must be trimmed off before sorting."
+        )
 
-    values_3d = candidates.copy().reshape(n_periods, n_columns, n_timesteps)
+    values_3d = candidates.copy().reshape(n_periods, n_columns, n_timesteps_per_period)
     sorted_values = (-np.sort(-values_3d, axis=2, kind="stable")).reshape(n_periods, -1)
 
     cluster_order = assign_clusters(

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -398,8 +398,12 @@ def cluster_candidates(
         else:
             cluster_centers, cluster_center_indices, cluster_order = (
                 cluster_sorted_periods(
-                    candidates,
+                    # Never the augmented matrix: this path reshapes its input
+                    # per column, and the period-sum block is not made of
+                    # timesteps, so including it shifts every column's block.
+                    rep_candidates if rep_candidates is not None else candidates,
                     period_profiles.n_columns,
+                    cfg.n_timesteps_per_period,
                     cfg.n_clusters,
                     cluster,
                 )

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -307,10 +307,17 @@ def prepare_data(
     # Add period sum features if requested
     # Period sums are extra columns appended for clustering distance only;
     # they must NOT reach representations() which expects original columns.
+    # They are summed from the *weighted* profiles so that a column's sum
+    # feature carries the same weight as its timestep features — summing the
+    # unweighted profiles would make a column's period sum count for relatively
+    # less the higher its weight.
     n_feature_cols = candidates.shape[1]
     if cluster.include_period_sums:
         candidates = add_period_sum_features(
-            period_profiles.profiles_dataframe, candidates
+            weighted_profiles_df
+            if weighted_profiles_df is not None
+            else period_profiles.profiles_dataframe,
+            candidates,
         )
 
     return PreparedData(

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -279,6 +279,13 @@ def prepare_data(
     representation_dict = _build_representation_dict(
         data.columns, cluster_representation
     )
+    # Segmentation is configured independently of clustering, so it gets its
+    # own dict rather than borrowing the cluster stage's.
+    segment_representation_dict = (
+        _build_representation_dict(data.columns, cfg.segments.representation)
+        if cfg.segments is not None
+        else None
+    )
     original_column_order = list(data.columns)
     original_data = data.copy()
 
@@ -330,6 +337,7 @@ def prepare_data(
         original_data=original_data,
         weight_vector=weight_vector,
         weighted_profiles_df=weighted_profiles_df,
+        segment_representation_dict=segment_representation_dict,
     )
 
 
@@ -558,7 +566,7 @@ def refine_representatives(
                 segmentation_input,
                 cfg.n_timesteps_per_period,
                 cfg.segments,
-                prepared.representation_dict,
+                prepared.segment_representation_dict,
                 cfg.predef,
             )
         )

--- a/src/tsam/pipeline/periods.py
+++ b/src/tsam/pipeline/periods.py
@@ -133,12 +133,18 @@ def add_period_sum_features(
     These extra columns influence **only** which periods get grouped — they are
     stripped from the cluster centers during post-processing (the trim step) so
     they never reach the representation logic, which expects the original
-    columns. When per-column weights are active they are already baked into
-    ``candidates``, so the sums are appended to the weighted candidates.
+    columns.
+
+    ``profiles_df`` and ``candidates`` must be in the **same space**: when
+    per-column weights are active, the caller passes the weighted profiles, so
+    a column's sum feature carries the same weight as its timestep features.
+    Summing unweighted profiles into weighted candidates would mean the higher
+    a column's weight, the *less* its period sum counts relative to its own
+    timesteps.
 
     Args:
-        profiles_df: The unstacked, normalized period profiles (used to compute
-            the per-period sums).
+        profiles_df: The unstacked, normalized period profiles the sums are
+            computed from — weighted if ``candidates`` is weighted.
         candidates: Current candidate matrix (possibly already weighted) to
             augment.
 

--- a/src/tsam/pipeline/types.py
+++ b/src/tsam/pipeline/types.py
@@ -151,12 +151,18 @@ class PreparedData:
         norm_data: Normalization state for later denormalization.
         period_profiles: The unstacked period profiles and metadata.
         candidates: Candidate period matrix (possibly weighted / augmented).
-        representation_dict: Per-column representation overrides.
+        representation_dict: Per-column representation overrides for the
+            **cluster** representation.
         n_feature_cols: Number of feature columns.
         original_column_order: Column order of the original input.
         original_data: Original input data (for rescale, bounds, reconstruct).
         weight_vector: Per-column weights baked into the candidates, if any.
         weighted_profiles_df: Weighted period profiles, if weights are active.
+        segment_representation_dict: Per-column representation overrides for the
+            **segment** representation. Separate from `representation_dict`
+            because the two stages are configured independently —
+            `ClusterConfig.representation` and `SegmentConfig.representation`
+            may each be a `MinMaxMean` naming different columns.
     """
 
     norm_data: NormalizedData
@@ -168,6 +174,7 @@ class PreparedData:
     original_data: pd.DataFrame
     weight_vector: np.ndarray | None = None
     weighted_profiles_df: pd.DataFrame | None = None
+    segment_representation_dict: dict[str, str] | None = None
 
     @property
     def attribute_columns(self) -> list[str]:

--- a/test/test_golden_regression.py
+++ b/test/test_golden_regression.py
@@ -51,13 +51,6 @@ pytestmark = [
 # has something to be verified against. ``strict`` means a fix turns the xfail
 # into an XPASS and forces the entry to be removed.
 _V4_REGRESSIONS: dict[str, str] = {
-    "period_sums_weighted/testdata": (
-        "include_period_sums + weights: v3 summed the *weighted* periodly "
-        "profiles into the extra features (weights were applied before "
-        "unstacking); v4's add_period_sum_features sums the unweighted "
-        "profiles_dataframe and appends them to weighted candidates, so column "
-        "weights no longer reach the period-sum features."
-    ),
     "segmentation_minmax_mean/testdata": (
         "SegmentConfig(representation=MinMaxMean(...)): v3 overrode "
         "representationDict from the segment representation; v4 only ever "

--- a/test/test_golden_regression.py
+++ b/test/test_golden_regression.py
@@ -58,13 +58,6 @@ _V4_REGRESSIONS: dict[str, str] = {
         "profiles_dataframe and appends them to weighted candidates, so column "
         "weights no longer reach the period-sum features."
     ),
-    "duration_curves_period_sums/testdata": (
-        "include_period_sums + use_duration_curves: v3's _clusterSortedPeriods "
-        "sorted normalizedPeriodlyProfiles (un-augmented); v4's "
-        "cluster_sorted_periods reshapes the *augmented* candidates with "
-        "n_timesteps = n_total // n_columns, which is off by one block and "
-        "sorts across column boundaries."
-    ),
     "segmentation_minmax_mean/testdata": (
         "SegmentConfig(representation=MinMaxMean(...)): v3 overrode "
         "representationDict from the segment representation; v4 only ever "

--- a/test/test_golden_regression.py
+++ b/test/test_golden_regression.py
@@ -51,12 +51,6 @@ pytestmark = [
 # has something to be verified against. ``strict`` means a fix turns the xfail
 # into an XPASS and forces the entry to be removed.
 _V4_REGRESSIONS: dict[str, str] = {
-    "segmentation_minmax_mean/testdata": (
-        "SegmentConfig(representation=MinMaxMean(...)): v3 overrode "
-        "representationDict from the segment representation; v4 only ever "
-        "derives representation_dict from ClusterConfig.representation, so the "
-        "per-column min/max assignment never reaches the segmentation kernel."
-    ),
     "segmentation_medoid/testdata": (
         "SegmentConfig(representation='medoid') diverges from v3 on a small "
         "number of segments (~0.4% of cells). Root cause not yet identified."

--- a/test/test_minmaxRepresentation.py
+++ b/test/test_minmaxRepresentation.py
@@ -4,7 +4,13 @@ import numpy as np
 import pandas as pd
 
 from conftest import TESTDATA_CSV
-from tsam import ClusterConfig, MinMaxMean, aggregate, unstack_to_periods
+from tsam import (
+    ClusterConfig,
+    MinMaxMean,
+    SegmentConfig,
+    aggregate,
+    unstack_to_periods,
+)
 
 
 def test_minmaxRepresentation():
@@ -62,6 +68,63 @@ def test_minmaxRepresentation():
             algorithmResult = typPeriods.loc[i, :].loc[:, j].values
             # print(calculated,algorithmResult)
             np.testing.assert_array_almost_equal(calculated, algorithmResult, decimal=4)
+
+
+def test_segment_and_cluster_minmax_are_independent():
+    """A MinMaxMean on SegmentConfig steers segments, not cluster centers.
+
+    v3 kept a single global ``representationDict`` and let the segment
+    representation overwrite the cluster one, so the two stages could not name
+    different columns. They are resolved separately now.
+    """
+    raw = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+    common = {
+        "n_clusters": 4,
+        "period_duration": 24,
+        "preserve_column_means": False,
+    }
+    cluster_minmax = ClusterConfig(
+        method="hierarchical",
+        representation=MinMaxMean(max_columns=["GHI"], min_columns=["T"]),
+    )
+
+    # Same cluster representation, different segment representations: if the
+    # segment dict were still shared with the cluster stage, these would be
+    # indistinguishable.
+    max_load = aggregate(
+        raw,
+        cluster=cluster_minmax,
+        segments=SegmentConfig(
+            n_segments=6, representation=MinMaxMean(max_columns=["Load"])
+        ),
+        **common,
+    )
+    min_load = aggregate(
+        raw,
+        cluster=cluster_minmax,
+        segments=SegmentConfig(
+            n_segments=6, representation=MinMaxMean(min_columns=["Load"])
+        ),
+        **common,
+    )
+
+    assert (
+        max_load.cluster_representatives["Load"].sum()
+        > min_load.cluster_representatives["Load"].sum()
+    ), "the segment representation did not reach the segmentation stage"
+
+    # The cluster representation is untouched by either: with no segmentation,
+    # GHI is still the per-cluster maximum.
+    unsegmented = aggregate(raw, cluster=cluster_minmax, **common)
+    periods = unstack_to_periods(raw, 24)
+    for cluster_no in range(4):
+        members = np.where(unsegmented.cluster_assignments == cluster_no)[0]
+        np.testing.assert_array_almost_equal(
+            periods.loc[members, "GHI"].max().values,
+            unsegmented.cluster_representatives.loc[cluster_no, "GHI"].values,
+            decimal=4,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #435 (which is stacked on #434). Fixes three of the four v3→v4 divergences #435 pinned, one commit each.

Each fix deletes its own `xfail` entry, so the golden generated from v3.4.2 is what verifies it.

## 1. `fix(clustering)`: period sums no longer corrupt duration-curve clustering

`cluster_sorted_periods` reshapes its input into one block of timesteps per column, deriving the block length as `candidates.shape[1] // n_columns`. That division cannot tell a wider block from an extra block: with `include_period_sums=True`, 4 columns × 24 timesteps + 4 sums divides cleanly into "4 columns × 25 timesteps". Every column's block was read one element into the next and the descending sort ran across column boundaries.

v3 never had this — `_clusterSortedPeriods` sorted `normalizedPeriodlyProfiles` and used the stripped `repr_candidates` for centers, so period sums simply did not participate in duration-curve clustering.

The block length is now **passed in** rather than derived, because the derivation is what made the mistake invisible — it succeeded and returned a plausible number. The function raises if the matrix is not exactly `n_columns * n_timesteps_per_period` wide.

## 2. `fix(pipeline)`: period-sum features are weighted like every other feature

`prepare_data` weighted the candidates, then appended sum features computed from the *unweighted* profiles. The candidate row mixed two spaces: a column with weight 5 had its 24 timestep features scaled by 5 and its sum feature left at 1, so **raising a column's weight shrank the relative influence of its period sum**.

v3 weighted before unstacking, so the whole row lived in one space. The sums now come from `weighted_profiles_df`, which `prepare_data` already keeps for extremes and segmentation. Unweighted runs are unaffected.

## 3. `fix(pipeline)!`: cluster and segment representations resolved independently

**BREAKING** — see the new migration-guide section.

`ClusterConfig.representation` and `SegmentConfig.representation` are two settings, but v3 resolved them into one global `representationDict` and applied the segment one last (`api.py:692`), so a `MinMaxMean` on `SegmentConfig` silently overwrote the cluster stage's assignment. The pipeline inherited half of that — the dict was only ever built from `ClusterConfig.representation` and handed to both stages, making the segment setting a no-op.

Each stage now builds its own dict. Chosen over reinstating the v3 overwrite because the only configurations where the two differ are those naming columns on *both* stages, and there v3's answer was not one anybody asked for.

`test_segment_and_cluster_minmax_are_independent` pins the behaviour v3 could not express.

## Still open from #435

`segmentation_medoid` remains xfail: diverges from v3 on ~0.4% of cells, root cause not yet identified.

## Verification

- `pytest test/`: 537 passed, 145 skipped, 1 xfailed, 1 xpassed
- `pytest test/test_golden_regression.py`: 143 passed, 1 xfailed
- `ruff check` / `ruff format --check`: clean
- `mkdocs build --strict`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
