### PR TITLE
fix(result): make apply() faithful to the run it replays

### DIFF
--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -710,8 +710,11 @@ class ClusteringResult:
             the aggregation was unweighted.
         time_index: Original ``DatetimeIndex`` of the input data, kept so that
             ``disaggregate()`` can round-trip results to the original timestamps.
-        cluster_config: Reference only. Clustering configuration used to create
-            this result.
+        cluster_config: Clustering configuration used to create this result.
+            `apply()` replays under it, so settings that shape the data rather
+            than the assignment — `scale_by_column_means`, `include_period_sums`
+            — survive a transfer. Falls back to `representation` alone when
+            absent.
         segment_config: Reference only. Segmentation configuration used to create
             this result.
         extremes_config: Reference only. Extreme-period configuration used to
@@ -746,7 +749,8 @@ class ClusteringResult:
     # === Index fields (for disaggregate() round-trip) ===
     time_index: pd.DatetimeIndex | None = None
 
-    # === Reference fields (for documentation, not used by apply()) ===
+    # === Config fields (cluster_config is replayed by apply(); the other two
+    # are reference only) ===
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
     extremes_config: ExtremeConfig | None = None
@@ -1279,8 +1283,12 @@ class ClusteringResult:
                 f"but clustering expects {self.n_original_periods} periods"
             )
 
-        # Build minimal ClusterConfig with just the representation.
-        cluster = ClusterConfig(representation=self.representation)
+        # Settings like scale_by_column_means shape the data, not just the
+        # assignment, so the replay needs the whole config. Hand-built results
+        # may not carry one.
+        cluster = self.cluster_config or ClusterConfig(
+            representation=self.representation
+        )
 
         # Validate (and normalize) the stored weights against the new data
         from tsam.weights import validate_weights

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -1076,6 +1076,36 @@ class ClusteringResult:
             kwargs["extremes_config"] = ExtremeConfig.from_dict(data["extremes_config"])
         return cls(**kwargs)
 
+    def _inexact_transfer_reason(self) -> str | None:
+        """Why replaying this clustering cannot reproduce it exactly, if it cannot.
+
+        Returns None when a transfer is exact. Both cases below come from
+        extreme-period handling changing the representatives after the fact:
+        `apply()` replays the stored assignment, and the stored assignment is
+        not what those representatives were built from.
+        """
+        if self.extremes_config is None:
+            return None
+        if self.extremes_config.method == "replace":
+            return (
+                "the 'replace' extreme method builds a hybrid representative — "
+                "some columns from the cluster representative, some from the "
+                "extreme period. A transfer uses the stored cluster centers "
+                "directly, without that injection. Use 'append' or "
+                "'new_cluster' for an exact transfer"
+            )
+        if self.cluster_centers is None:
+            return (
+                f"the {self.extremes_config.method!r} extreme method moves a "
+                "period into its own cluster after that period's original "
+                "cluster was represented, and this representation is computed "
+                "from the cluster members rather than stored as a period index. "
+                "A transfer therefore recomputes that one cluster without the "
+                "moved period. Use a 'medoid' or 'maxoid' representation for an "
+                "exact transfer"
+            )
+        return None
+
     def to_json(self, path: str) -> None:
         """Save clustering result to a JSON file.
 
@@ -1092,17 +1122,11 @@ class ClusteringResult:
         """
         import json
 
-        # Warn if using replace extreme method (transfer is not exact)
-        if (
-            self.extremes_config is not None
-            and self.extremes_config.method == "replace"
-        ):
+        reason = self._inexact_transfer_reason()
+        if reason is not None:
             warnings.warn(
-                "Saving a clustering that used the 'replace' extreme method. "
-                "The 'replace' method creates a hybrid cluster representation "
-                "(some columns from the medoid, some from the extreme period) that "
-                "cannot be perfectly reproduced when loaded and applied later. "
-                "For exact transfer, use 'append' or 'new_cluster' extreme methods.",
+                "Saving a clustering that cannot be reproduced exactly when it "
+                f"is loaded and applied later: {reason}.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -1214,17 +1238,29 @@ class ClusteringResult:
             Aggregation result using this clustering.
 
         Note:
-            **Extreme period transfer limitations:**
+            **Extreme period transfer limitations.** Extreme-period handling
+            runs *after* the representatives have been computed, and only the
+            assignment it leaves behind is stored. Two configurations therefore
+            cannot be replayed exactly, and both emit a `UserWarning`:
 
-            The 'replace' extreme method creates a hybrid cluster representation
-            where some columns use the medoid values and others use the extreme
-            period values. This hybrid representation cannot be perfectly
-            reproduced during transfer. When applying a clustering that used
-            'replace', a warning will be issued and the transferred result will
-            use the medoid representation for all columns.
+            - **`method="replace"`** builds a hybrid representative — some
+              columns from the cluster representative, some from the extreme
+              period. A transfer uses the stored cluster centers directly,
+              without that injection.
+            - **`method="append"` or `"new_cluster"` with a representation that
+              is *computed* rather than *selected*** (`"mean"`, `"distribution"`,
+              `"minmax_mean"`, …). These methods move a period into its own
+              cluster after that period's original cluster was represented. A
+              selected representation (`"medoid"`, `"maxoid"`) stores the chosen
+              period's index and replays exactly; a computed one is recomputed
+              from the stored assignment, which no longer contains the moved
+              period, so that one cluster differs. With
+              `preserve_column_means=True` the rescaling then spreads the
+              difference across every cluster.
 
-            For exact transfer with extreme periods, use 'append' or 'new_cluster'
-            extreme methods instead.
+            For an exact transfer with extreme periods, use `"append"` or
+            `"new_cluster"` together with a `"medoid"` or `"maxoid"`
+            representation.
 
         Examples:
             >>> # Cluster on wind data, apply to full dataset
@@ -1239,18 +1275,10 @@ class ClusteringResult:
         from tsam.pipeline import run_pipeline
         from tsam.pipeline.types import PipelineConfig, PredefParams
 
-        # Warn if using replace extreme method (transfer is not exact)
-        if (
-            self.extremes_config is not None
-            and self.extremes_config.method == "replace"
-        ):
+        reason = self._inexact_transfer_reason()
+        if reason is not None:
             warnings.warn(
-                "The 'replace' extreme method creates a hybrid cluster representation "
-                "(some columns from the cluster representative, some from the extreme period) "
-                "that cannot be perfectly reproduced during transfer. The transferred result "
-                "will use the stored cluster center periods directly, without the extreme "
-                "value injection that was applied during the original aggregation. "
-                "For exact transfer, use 'append' or 'new_cluster' extreme methods.",
+                f"This clustering cannot be replayed exactly: {reason}.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
@@ -1275,12 +1276,16 @@ class ClusteringResult:
                 f"but clustering expects {self.n_timesteps_per_period} timesteps per period"
             )
 
-        # Validate number of periods matches
-        n_periods_in_data = len(data) // self.n_timesteps_per_period
+        # Rounded up, matching how the pipeline counts: a series that does not
+        # fill whole periods has its last period padded, and that padded period
+        # is in cluster_assignments.
+        n_periods_in_data = math.ceil(len(data) / self.n_timesteps_per_period)
         if n_periods_in_data != self.n_original_periods:
             raise ValueError(
-                f"Data has {n_periods_in_data} periods, "
-                f"but clustering expects {self.n_original_periods} periods"
+                f"Data has {n_periods_in_data} periods "
+                f"({len(data)} timesteps at {self.n_timesteps_per_period} per "
+                f"period), but clustering expects {self.n_original_periods} "
+                "periods"
             )
 
         # Settings like scale_by_column_means shape the data, not just the

--- a/test/test_clustering_e2e.py
+++ b/test/test_clustering_e2e.py
@@ -376,6 +376,36 @@ class TestClusteringTransfer:
             atol=1e-10,
         )
 
+    def test_apply_warns_when_extremes_cannot_be_replayed(self, input_data):
+        """append + a computed representation loses a cluster's members."""
+        result = run_aggregation(
+            input_data,
+            ClusteringTestCase(
+                id="append_mean",
+                method="hierarchical",
+                representation="mean",
+                extreme_method="append",
+                extreme_columns=["Load"],
+            ),
+        )
+        with pytest.warns(UserWarning, match="cannot be replayed exactly"):
+            result.clustering.apply(input_data)
+
+    def test_apply_is_silent_when_extremes_can_be_replayed(self, input_data, recwarn):
+        """A selected representation stores the period index, so it replays."""
+        result = run_aggregation(
+            input_data,
+            ClusteringTestCase(
+                id="append_medoid",
+                method="hierarchical",
+                representation="medoid",
+                extreme_method="append",
+                extreme_columns=["Load"],
+            ),
+        )
+        result.clustering.apply(input_data)
+        assert not [w for w in recwarn if "replayed exactly" in str(w.message)]
+
     @pytest.mark.parametrize(
         "test_case", TRANSFER_TEST_CASES, ids=get_transfer_test_ids()
     )

--- a/test/test_golden_regression.py
+++ b/test/test_golden_regression.py
@@ -73,13 +73,6 @@ def _parametrized_cases():
     ]
 
 
-_PARTIAL_PERIOD_REJECTED = (
-    "apply() validates len(data) // n_timesteps_per_period against "
-    "n_original_periods. The padded partial last period is counted in the "
-    "latter but floored out of the former, so a clustering built from a series "
-    "that does not fill whole periods raises 'Data has N periods, but "
-    "clustering expects N+1' — even when replayed on its own input."
-)
 _APPEND_SHIFTS_MEAN = (
     "extremes='append' moves a period out of its original cluster *after* the "
     "centers were computed, so the stored center includes a period the stored "
@@ -98,8 +91,6 @@ _TRANSFER_NOT_EXACT: dict[str, str] = {
     "stored assignment cannot reconstruct — ClusteringResult.apply() warns",
     "extremes_replace_segmentation": "same as extremes_replace, with segmentation",
     # --- defects ---
-    "period_week": _PARTIAL_PERIOD_REJECTED,
-    "period_48h": _PARTIAL_PERIOD_REJECTED,
     "kmeans_extremes_append": _APPEND_SHIFTS_MEAN,
     "averaging_extremes_append": _APPEND_SHIFTS_MEAN,
 }

--- a/test/test_golden_regression.py
+++ b/test/test_golden_regression.py
@@ -73,12 +73,6 @@ def _parametrized_cases():
     ]
 
 
-_SAMEMEAN_LOST = (
-    "ClusterConfig.scale_by_column_means is not stored on ClusteringResult at "
-    "all, and apply() rebuilds the config as "
-    "ClusterConfig(representation=self.representation), so the setting silently "
-    "reverts to False on transfer."
-)
 _PARTIAL_PERIOD_REJECTED = (
     "apply() validates len(data) // n_timesteps_per_period against "
     "n_original_periods. The padded partial last period is counted in the "
@@ -104,11 +98,6 @@ _TRANSFER_NOT_EXACT: dict[str, str] = {
     "stored assignment cannot reconstruct — ClusteringResult.apply() warns",
     "extremes_replace_segmentation": "same as extremes_replace, with segmentation",
     # --- defects ---
-    "segmentation_samemean": _SAMEMEAN_LOST,
-    "hierarchical_weighted_samemean": _SAMEMEAN_LOST,
-    "hierarchical_weighted_segmentation_samemean": _SAMEMEAN_LOST,
-    "samemean_unweighted": _SAMEMEAN_LOST,
-    "samemean_extremes": _SAMEMEAN_LOST,
     "period_week": _PARTIAL_PERIOD_REJECTED,
     "period_48h": _PARTIAL_PERIOD_REJECTED,
     "kmeans_extremes_append": _APPEND_SHIFTS_MEAN,


### PR DESCRIPTION
Stacked on #437 → #436 → #435 → #434. Fixes two of the three transfer defects #437 pinned, one commit each; each deletes its own `xfail` entry.

## 1. `apply()` replays under the stored `ClusterConfig`

It rebuilt the configuration as `ClusterConfig(representation=self.representation)` — keeping the representation, defaulting everything else. `scale_by_column_means` was the one that mattered: it changes how the data is *normalized*, not how it is assigned, so a clustering built with it came back silently rescaled.

`ClusteringResult` has carried `cluster_config` all along and it already round-trips through `to_dict`/`from_dict`; it was just labelled "reference only, not used by `apply()`". Replaying under it fixes the whole class of data-shaping settings instead of threading one more field through. The old construction stays as the fallback for hand-built results.

Fixes 5 configurations.

## 2. `apply()` accepts a padded partial last period

It compared `len(data) // n_timesteps_per_period` against `n_original_periods`. Those count differently: a series that does not fill whole periods has its last period padded, and `cluster_assignments` — hence `n_original_periods` — includes it, while the floor drops it.

A year of hourly data clustered into weekly periods (8760 timesteps, 52.14 periods) therefore produced a `ClusteringResult` that **could not be applied to anything**, including the data it came from: `Data has 52 periods, but clustering expects 53`. Counting up matches the pipeline and keeps the check doing its job.

Fixes 2 configurations.

## 3. The remaining case is documented and warned about, not fixed

`extremes="append"`/`"new_cluster"` with a representation that is *computed*
(`"mean"`, `"distribution"`, `"minmax_mean"`) rather than *selected*
(`"medoid"`, `"maxoid"`). Isolating the rescaling shows the mechanism exactly —
with `preserve_column_means=False`, **only the extreme period's origin cluster
differs**, every other cluster is bit-identical:

```
preserve_column_means=False  per-cluster maxabs: {0: 0.0, 1: 1.8037, 2: 0.0, ..., 8: 0.0}
preserve_column_means=True   per-cluster maxabs: {0: 0.11, 1: 0.22, 2: 0.38, 3: 4.30, ...}
```

These methods move a period into its own cluster *after* that period's original
cluster was represented, so the stored assignment is not the one the
representatives were built from — and only one of the two is stored.

`apply()` and `to_json()` now warn, and the `apply()` docstring names both
inexact cases and the combination that does replay exactly. Both conditions
resolve through one `_inexact_transfer_reason()` helper, which also corrects the
old advice: the previous docstring said "use `append` or `new_cluster` for exact
transfer", which is only true for half of them.

I prototyped the actual fix — storing the pre-extreme assignment and recomputing
representatives from it. It is not sufficient: that assignment has 8 clusters
where the result has 9, so the extreme clusters lose their centers entirely.
Doing it properly needs a second stored field (the extreme periods' indices) plus
per-method handling, since `append`, `new_cluster` and `replace` each rearrange
clusters differently. That is a design change, not a patch.

The alternative — computing representatives *after* extreme integration, which is
self-consistent — changes what `aggregate()` produces for every extremes
configuration and breaks the v3 parity #435 establishes.

## Verification

- `pytest test/`: 680 passed, 145 skipped, 6 xfailed, 1 xpassed
- `ruff check` / `ruff format --check`: clean
- `mkdocs build --strict`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
