### PR TITLE
test: name the two breaking changes nothing asserts directly

### DIFF
--- a/test/test_v4_contracts.py
+++ b/test/test_v4_contracts.py
@@ -1,0 +1,52 @@
+"""Named assertions for the two v3 -> v4 breaking changes nothing states directly.
+
+Both are already covered incidentally — reverting the column order fails 20
+tests, and removing the legacy API would fail every import of it. Neither
+failure *says* what broke, though: a reader watching
+`test_distributionMinMaxRepresentation` fail has no reason to suspect the
+column-order contract. These tests exist so that the breakage names itself.
+"""
+
+import importlib.util
+
+import pandas as pd
+import pytest
+
+from conftest import TESTDATA_CSV
+from tsam import aggregate
+
+# testdata.csv is deliberately not alphabetical, so sorting and preserving the
+# input order are distinguishable. A fixture in alphabetical order would make
+# this test pass under either behaviour.
+RAW = pd.read_csv(TESTDATA_CSV, index_col=0)
+
+
+def test_fixture_is_not_alphabetical():
+    """Guard for the two tests below, which are vacuous without it."""
+    assert list(RAW.columns) != sorted(RAW.columns)
+
+
+def test_outputs_keep_the_input_column_order():
+    """v3 sorted output columns alphabetically; v4 returns them as given."""
+    result = aggregate(RAW.copy(), n_clusters=4, period_duration=24)
+
+    assert list(result.cluster_representatives.columns) == list(RAW.columns)
+    assert list(result.reconstructed.columns) == list(RAW.columns)
+    assert list(result.original.columns) == list(RAW.columns)
+
+
+@pytest.mark.parametrize(
+    "module", ["tsam.timeseriesaggregation", "tsam.hyperparametertuning"]
+)
+def test_legacy_modules_are_gone(module):
+    """v4 removed the class-based API; `tsam.aggregate()` is the entry point."""
+    assert importlib.util.find_spec(module) is None
+
+
+@pytest.mark.parametrize(
+    "name", ["TimeSeriesAggregation", "unstackToPeriods", "LegacyAPIWarning"]
+)
+def test_legacy_names_are_gone(name):
+    import tsam
+
+    assert not hasattr(tsam, name)


### PR DESCRIPTION
Adds `test/test_v4_contracts.py`. No production changes.

## Why, honestly

Both contracts are **already covered** — this is about legibility, not a hole.

Reverting the column order to v3's alphabetical sort fails **20 tests**:
`test_distributionMinMaxRepresentation`,
`test_periodwise_minmax_preserves_integral_without_rescaling`,
`test_apply_to_different_data` and others, all of which index columns
positionally and break as a side effect. Nothing in that output tells a reader
the column-order contract is what broke. Same for the legacy API: removing it
would fail any import, but no test says "this is gone on purpose".

`develop` had `test_column_order_warning.py` covering the v3-side
`FutureWarning`. It was correctly dropped when the warning went away — but the
successor property was never asserted in its place.

## What it adds

| Test | Asserts |
|---|---|
| `test_outputs_keep_the_input_column_order` | `cluster_representatives`, `reconstructed` and `original` all return columns in input order |
| `test_legacy_modules_are_gone` | `tsam.timeseriesaggregation`, `tsam.hyperparametertuning` have no spec |
| `test_legacy_names_are_gone` | `TimeSeriesAggregation`, `unstackToPeriods`, `LegacyAPIWarning` absent from `tsam` |
| `test_fixture_is_not_alphabetical` | guard — see below |

That last one matters more than it looks. `testdata.csv` is deliberately
`GHI, T, Wind, Load`; if it were ever replaced with an alphabetical fixture, the
column-order test would pass under **either** behaviour and quietly stop
testing anything. The guard makes that failure loud.

The column-order test is mutation-checked: sorting the output columns in
`build_result` fails it, and nothing else in the file.

## Where this leaves the breaking-change pins

| Breaking change | Pinned by |
|---|---|
| Cluster/segment representation split | `test_minmaxRepresentation.py` — mutation-checked both directions |
| Deterministic tie-break | `test_representation_tiebreak.py`, incl. a one-ULP perturbation |
| `MinMaxMean` rejects bad columns | `test_assert_raises.py` |
| `apply()` replays the stored `ClusterConfig` | golden matrix, all 90 configurations |
| **Column order** | **this PR** |
| **Legacy API removed** | **this PR** |

## Verification

- `pytest test/`: 695 passed, 145 skipped, 5 xfailed, 1 xpassed
- `ruff check` / `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)