### PR TITLE
ci(publish): only publish for release tags, and gate the release on the build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
 
 permissions:
   contents: write
@@ -37,6 +37,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
+    needs: publish
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Draft — found while preparing the v4 release.

## What happened

`publish.yaml` triggers on `tags: ["v*"]`. I pushed an archive tag,
`v4-development-history`, to keep the 136 pre-squash v4 commits reachable after
#234 was squash-merged. It matched the glob, so:

- the **PyPI build ran** — and failed only because `hatch-vcs` cannot derive a
  PEP 440 version from that tag name. The upload step was skipped, so nothing
  reached PyPI (still 3.4.2, no 4.x).
- the **GitHub release job succeeded independently** and published a release for
  that tag, which had to be deleted by hand.

The tag has since been renamed to `history/v4-development`, which matches
nothing and triggered no workflow.

## Two fixes

**1. Require a semver-shaped tag.**

```yaml
tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
```

Checked against the tags this repo actually uses:

| Tag | Before | After |
|---|---|---|
| `v3.4.2`, `v3.4.1`, `v2.3.9` | match | match |
| `v3.2.0rc0` | match | match |
| `v4.0.0` | match | match |
| `v4-development-history` | **match** | skip |
| `v4`, `v4-dev`, `vnext` | **match** | skip |

**2. `github-release` now `needs: publish`.**

The jobs were independent, so a build that cannot even produce a wheel still
opened a release. Gating means a tag that cannot be packaged cannot be released.

Trade-off worth a look: a *transient* PyPI failure on a legitimate tag now also
blocks the release, where before it would have been created anyway. Re-running
the job covers that, and it seems the safer default — a release pointing at a
version that was never published is worse than one that needs a re-run.

## Why it matters now

The glob is most dangerous during a release week, which is exactly when someone
tags something by hand. Left alone, the next `v`-prefixed tag repeats this.

## Verification

- glob checked against 10 tag names, real and hypothetical (table above)
- `pre-commit run --files .github/workflows/publish.yaml`: `check yaml` passes
- no behaviour change for release tags: `v4.0.0` still triggers both jobs, in
  order

🤖 Generated with [Claude Code](https://claude.com/claude-code)