### PR TITLE
perf: expand disaggregate() with numpy gathers

### DIFF
--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -6,7 +6,7 @@ import math
 import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import numpy as np
 import pandas as pd
@@ -561,8 +561,10 @@ def _validate_disaggregate_input(
         data = data.droplevel(list(range(2, data.index.nlevels)))
 
     # Validate cluster IDs
-    data_clusters = set(data.index.get_level_values(0).unique())
-    expected_clusters = set(clustering.cluster_assignments)
+    cluster_level = data.index.get_level_values(0)
+    unique_clusters = cluster_level.unique()
+    data_clusters = set(unique_clusters)
+    expected_clusters = clustering._cluster_id_set
     if data_clusters != expected_clusters:
         missing = expected_clusters - data_clusters
         extra = data_clusters - expected_clusters
@@ -585,14 +587,220 @@ def _validate_disaggregate_input(
         expected = clustering.n_timesteps_per_period
         kind = "timesteps"
 
-    for cluster in data.index.get_level_values(0).unique():
-        n_in_cluster = len(data.loc[cluster])
-        if n_in_cluster != expected:
-            raise ValueError(
-                f"cluster {cluster} has {n_in_cluster} {kind}, expected {expected}"
-            )
+    counts = cluster_level.value_counts()
+    mismatched = counts[counts != expected]
+    if len(mismatched):
+        # Report the first offending cluster in index order, as a row-wise scan would.
+        cluster = next(c for c in unique_clusters if c in mismatched.index)
+        raise ValueError(
+            f"cluster {cluster} has {int(mismatched[cluster])} {kind}, "
+            f"expected {expected}"
+        )
 
     return data
+
+
+class _PeriodGrid(NamedTuple):
+    """A regular ``(cluster, inner)`` index laid out as equal contiguous blocks.
+
+    Attributes:
+        labels: Cluster label of each block, in index order.
+        block_size: Rows per block — timesteps per period, or segments per
+            period for segment-level data.
+    """
+
+    labels: np.ndarray
+    block_size: int
+
+
+def _uniform_numpy_dtype(data: pd.DataFrame) -> np.dtype | None:
+    """The one numpy dtype shared by every column, or None if there isn't one.
+
+    A frame with a single dtype has values that reshape as one block, which is
+    what the numpy fast paths need. Mixed dtypes and pandas extension dtypes
+    (which have no numpy equivalent) return None.
+
+    Args:
+        data: Frame to inspect.
+
+    Returns:
+        The shared dtype, or None if the columns disagree, are extension
+        dtypes, or there are no columns at all.
+    """
+    dtypes = data.dtypes.to_numpy()
+    if len(dtypes) == 0 or not isinstance(dtypes[0], np.dtype):
+        return None
+    if not (dtypes == dtypes[0]).all():
+        return None
+    return cast("np.dtype", dtypes[0])
+
+
+def _period_grid(index: pd.MultiIndex) -> _PeriodGrid | None:
+    """Describe ``index`` as a regular period grid, or None if it is irregular.
+
+    A regular grid gives every cluster one contiguous block of equal length,
+    each block carrying the same ascending inner labels — the layout of every
+    typical-period frame tsam produces. On such a grid, expanding periods is a
+    gather along the cluster axis rather than an unstack/stack round trip.
+
+    Args:
+        index: Two-level ``(cluster, timestep)`` or ``(cluster, segment)``
+            MultiIndex.
+
+    Returns:
+        The grid description, or None if the layout is irregular.
+    """
+    n_rows = len(index)
+    clusters = index.get_level_values(0).to_numpy()
+    is_block_start = np.concatenate(([True], clusters[1:] != clusters[:-1]))
+    starts = np.flatnonzero(is_block_start)
+    n_blocks = len(starts)
+    if n_blocks == 0 or n_rows % n_blocks:
+        return None
+
+    block_size = n_rows // n_blocks
+    if not np.array_equal(starts, np.arange(n_blocks) * block_size):
+        return None
+
+    labels = clusters[starts]
+    if not pd.Index(labels).is_unique:
+        return None
+
+    inner = index.get_level_values(1).to_numpy().reshape(n_blocks, block_size)
+    if not (inner == inner[0]).all():
+        return None
+    # unstack() sorts the inner level, so only ascending blocks expand identically.
+    first_block = pd.Index(inner[0])
+    if not (first_block.is_monotonic_increasing and first_block.is_unique):
+        return None
+
+    return _PeriodGrid(labels=labels, block_size=block_size)
+
+
+def _block_positions(
+    block_labels: np.ndarray,
+    cluster_assignments: tuple[int, ...],
+) -> np.ndarray | None:
+    """Positions in ``block_labels`` for each assigned cluster, or None if unknown.
+
+    Args:
+        block_labels: Cluster label of each block, in index order.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Integer positions to gather, or None if any assignment is not a known
+        block label.
+    """
+    assignments = np.asarray(cluster_assignments)
+    n_blocks = len(block_labels)
+    labels_are_positions = block_labels.dtype.kind in "iu" and np.array_equal(
+        block_labels, np.arange(n_blocks)
+    )
+    if not labels_are_positions:
+        positions = pd.Index(block_labels).get_indexer(pd.Index(assignments))
+        return None if (positions < 0).any() else positions
+
+    # The usual case: clusters are labelled 0..n-1, so the labels are positions.
+    if assignments.dtype.kind not in "iu":
+        return None
+    if not ((assignments >= 0) & (assignments < n_blocks)).all():
+        return None
+    return assignments
+
+
+def _expand_periods(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame:
+    """Expand typical-period data to original time series length.
+
+    Selects rows from ``data`` according to ``cluster_assignments``, mapping
+    each original period to its cluster representative.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with integer index, one row per original timestep.
+    """
+    fast = _expand_periods_fast(data, cluster_assignments)
+    if fast is not None:
+        return fast
+    return _expand_periods_pandas(data, cluster_assignments)
+
+
+def _expand_periods_fast(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame | None:
+    """Expand periods by gathering rows in numpy, or None if not applicable.
+
+    Applies on a regular period grid whose columns share one numpy dtype.
+    Anything else (irregular grid, mixed or extension dtypes, unknown cluster
+    labels) returns None and the caller falls back to the pandas path.
+
+    The gather writes into a pre-transposed buffer so the result can be wrapped
+    without copying while keeping pandas' native column-major block layout.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with a RangeIndex, or None if the fast path does not apply.
+    """
+    dtype = _uniform_numpy_dtype(data)
+    if dtype is None:
+        return None
+
+    grid = _period_grid(data.index)  # type: ignore[arg-type]
+    if grid is None:
+        return None
+
+    positions = _block_positions(grid.labels, cluster_assignments)
+    if positions is None:
+        return None
+
+    n_columns = data.shape[1]
+    n_periods = len(positions)
+    n_rows = n_periods * grid.block_size
+
+    source = data.to_numpy().T.reshape(n_columns, len(grid.labels), grid.block_size)
+    gathered = np.empty((n_columns, n_periods, grid.block_size), dtype=dtype)
+    np.take(source, positions, axis=1, out=gathered)
+
+    return pd.DataFrame(
+        gathered.reshape(n_columns, n_rows).T,
+        index=pd.RangeIndex(n_rows),
+        columns=data.columns,
+        copy=False,
+    )
+
+
+def _expand_periods_pandas(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame:
+    """Expand periods via unstack/stack, for any index layout or dtype mix.
+
+    The general fallback behind :func:`_expand_periods_fast`.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with integer index, one row per original timestep.
+    """
+    unstacked = data.unstack(level=1)  # rows=cluster, cols=(col, timestep)
+    expanded = unstacked.loc[list(cluster_assignments)]
+    expanded.index = range(len(cluster_assignments))
+    # Use level=-1 to always stack the timestep level (last), which is correct
+    # even when the original columns are a MultiIndex.
+    result: pd.DataFrame = expanded.stack(future_stack=True, level=-1)  # type: ignore[assignment]
+    result.index = pd.RangeIndex(len(result))
+    return result
 
 
 def _expand_segments_to_timesteps(
@@ -615,6 +823,82 @@ def _expand_segments_to_timesteps(
         Data with ``(cluster, timestep)`` MultiIndex at full resolution.
         Only the first timestep of each segment has values; the rest are NaN.
     """
+    fast = _expand_segments_fast(data, segment_durations)
+    if fast is not None:
+        return fast
+    return _expand_segments_pandas(data, segment_durations)
+
+
+def _expand_segments_fast(
+    data: pd.DataFrame,
+    segment_durations: tuple[tuple[int, ...], ...],
+) -> pd.DataFrame | None:
+    """Scatter segment values into a NaN buffer, or None if not applicable.
+
+    Applies on a regular ``(cluster, segment)`` grid whose columns share one
+    numeric numpy dtype and whose periods all have the same length. Anything
+    else returns None and the caller falls back to the pandas path.
+
+    Args:
+        data: Segmented data with ``(cluster, segment)`` MultiIndex.
+        segment_durations: Duration per segment per cluster, ordered by sorted
+            cluster ID.
+
+    Returns:
+        Data with ``(cluster, timestep)`` MultiIndex, or None if the fast path
+        does not apply.
+    """
+    dtype = _uniform_numpy_dtype(data)
+    if dtype is None or dtype.kind not in "fiub":
+        return None
+
+    grid = _period_grid(data.index)  # type: ignore[arg-type]
+    if grid is None:
+        return None
+
+    n_blocks = len(grid.labels)
+    if len(segment_durations) != n_blocks:
+        return None
+    if any(len(d) != grid.block_size for d in segment_durations):
+        return None
+
+    period_lengths = {sum(d) for d in segment_durations}
+    if len(period_lengths) != 1:
+        return None
+    n_timesteps = period_lengths.pop()
+
+    # segment_durations is keyed by sorted cluster ID while the index runs in
+    # appearance order, so reorder it by each block label's rank. The double
+    # argsort turns a sort permutation into the rank of every element.
+    label_ranks = np.argsort(np.argsort(grid.labels))
+    durations = np.asarray(segment_durations)[label_ranks]
+
+    # Each segment writes at the timestep its predecessors have used up.
+    starts = np.zeros((n_blocks, grid.block_size), dtype=np.intp)
+    starts[:, 1:] = np.cumsum(durations, axis=1)[:, :-1]
+    rows = (np.arange(n_blocks)[:, None] * n_timesteps + starts).ravel()
+
+    values = np.full((n_blocks * n_timesteps, data.shape[1]), np.nan)
+    values[rows] = data.to_numpy()
+    index = pd.MultiIndex.from_product([grid.labels, range(n_timesteps)])
+    return pd.DataFrame(values, index=index, columns=data.columns)
+
+
+def _expand_segments_pandas(
+    data: pd.DataFrame,
+    segment_durations: tuple[tuple[int, ...], ...],
+) -> pd.DataFrame:
+    """Expand segments cluster by cluster, for any index layout or dtype mix.
+
+    The general fallback behind :func:`_expand_segments_fast`.
+
+    Args:
+        data: Segmented data with ``(cluster, segment)`` MultiIndex.
+        segment_durations: Duration per segment per cluster.
+
+    Returns:
+        Data with ``(cluster, timestep)`` MultiIndex at full resolution.
+    """
     clusters = data.index.get_level_values(0).unique()
     # Map cluster IDs to their segment durations. segment_durations is ordered
     # by unique cluster ID (sorted), not by positional index — so we zip with
@@ -636,32 +920,6 @@ def _expand_segments_to_timesteps(
         parts.append(pd.DataFrame(values, index=idx, columns=data.columns))
 
     return cast("pd.DataFrame", pd.concat(parts))
-
-
-def _expand_periods(
-    data: pd.DataFrame,
-    cluster_assignments: tuple[int, ...],
-) -> pd.DataFrame:
-    """Expand typical-period data to original time series length.
-
-    Selects rows from ``data`` according to ``cluster_assignments``, mapping
-    each original period to its cluster representative.
-
-    Args:
-        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
-        cluster_assignments: Cluster assignment for each original period.
-
-    Returns:
-        Flat DataFrame with integer index, one row per original timestep.
-    """
-    unstacked = data.unstack(level=1)  # rows=cluster, cols=(col, timestep)
-    expanded = unstacked.loc[list(cluster_assignments)]
-    expanded.index = range(len(cluster_assignments))
-    # Use level=-1 to always stack the timestep level (last), which is correct
-    # even when the original columns are a MultiIndex.
-    result: pd.DataFrame = expanded.stack(future_stack=True, level=-1)  # type: ignore[assignment]
-    result.index = pd.RangeIndex(len(result))
-    return result
 
 
 @dataclass(frozen=True)
@@ -896,10 +1154,15 @@ class ClusteringResult:
 
         return tuple(assignments_list), tuple(durations_list), centers
 
+    @cached_property
+    def _cluster_id_set(self) -> frozenset[int]:
+        """Distinct cluster IDs, cached so repeated disaggregation stays cheap."""
+        return frozenset(self.cluster_assignments)
+
     @property
     def n_clusters(self) -> int:
         """Number of clusters (typical periods)."""
-        return len(set(self.cluster_assignments))
+        return len(self._cluster_id_set)
 
     @property
     def n_original_periods(self) -> int:

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -8,6 +8,13 @@ import pytest
 
 from conftest import TESTDATA_CSV
 from tsam import ClusteringResult, SegmentConfig, aggregate
+from tsam.result import (
+    _expand_periods,
+    _expand_periods_fast,
+    _expand_periods_pandas,
+    _expand_segments_fast,
+    _expand_segments_pandas,
+)
 
 
 @pytest.fixture
@@ -399,3 +406,237 @@ class TestDisaggregateValidation:
         wrong = result.cluster_representatives.iloc[::2]
         with pytest.raises(ValueError, match="timesteps"):
             result.clustering.disaggregate(wrong)
+
+
+def _grid(clusters, n_timesteps, n_columns=3, dtype=float, columns=None, seed=0):
+    """Build a typical-period frame on a regular (cluster, timestep) grid."""
+    rng = np.random.default_rng(seed)
+    index = pd.MultiIndex.from_product(
+        [clusters, range(n_timesteps)], names=["cluster", "timestep"]
+    )
+    if columns is None:
+        columns = [f"c{i}" for i in range(n_columns)]
+    values = rng.random((len(index), len(columns)))
+    return pd.DataFrame(values.astype(dtype), index=index, columns=columns)
+
+
+class TestExpandPeriodsFastPath:
+    """The numpy gather must match the pandas fallback exactly (issue #432)."""
+
+    @pytest.mark.parametrize(
+        ("clusters", "assignments"),
+        [
+            ((0, 1, 2), (0, 2, 1, 1, 0)),
+            ((0,), (0, 0, 0)),
+            ((0, 3, 7), (7, 0, 3, 7, 7, 0)),
+            ((2, 0, 1), (0, 1, 2, 2, 0)),
+            ((0, 1, 2, 3), (3, 3, 3, 3)),
+        ],
+        ids=[
+            "contiguous",
+            "single",
+            "gapped-labels",
+            "unsorted-labels",
+            "one-repeated",
+        ],
+    )
+    def test_matches_pandas_path(self, clusters, assignments):
+        data = _grid(clusters, n_timesteps=4)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_multiindex_columns(self):
+        columns = pd.MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 1)])
+        data = _grid((0, 1, 2), n_timesteps=4, columns=columns)
+        assignments = (2, 0, 1, 2)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_nan_values_preserved(self):
+        """Segment expansion leaves NaN between segment starts."""
+        data = _grid((0, 1), n_timesteps=4)
+        data.iloc[1:3] = np.nan
+        assignments = (1, 0, 1)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_single_column_and_row_shapes(self):
+        data = _grid((0, 1), n_timesteps=1, n_columns=1)
+        assignments = (1, 1, 0)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        assert fast.shape == (3, 1)
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_result_uses_native_block_layout(self):
+        """Guard against handing back a transposed block, which slows every consumer."""
+        data = _grid((0, 1, 2), n_timesteps=24, n_columns=8)
+        fast = _expand_periods_fast(data, (0, 1, 2, 1, 0))
+        assert fast is not None
+        block = fast._mgr.blocks[0].values
+        assert block.shape == (8, 5 * 24)
+        assert block.flags.c_contiguous
+
+
+class TestExpandPeriodsFallback:
+    """Inputs the fast path must decline, leaving the pandas implementation."""
+
+    def test_mixed_dtypes(self):
+        data = _grid((0, 1), n_timesteps=3)
+        data["c0"] = data["c0"].astype("float32")
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_extension_dtype(self):
+        data = _grid((0, 1), n_timesteps=3).astype("Float64")
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_no_columns(self):
+        data = _grid((0, 1), n_timesteps=3).iloc[:, :0]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_unequal_block_sizes(self):
+        data = _grid((0, 1), n_timesteps=3).drop((1, 2))
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_noncontiguous_cluster_blocks(self):
+        """Same cluster appearing in two separate blocks is not a regular grid."""
+        data = _grid((0, 1), n_timesteps=2)
+        data = data.iloc[[0, 2, 1, 3]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_unsorted_timesteps_within_block(self):
+        """unstack() sorts timesteps, so the gather must decline unsorted blocks."""
+        data = _grid((0, 1), n_timesteps=3)
+        data = data.iloc[[2, 1, 0, 3, 4, 5]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_descending_timesteps_in_every_block(self):
+        """Blocks agree but run backwards; unstack() would reorder them, so decline."""
+        data = _grid((0, 1), n_timesteps=3)
+        data = data.iloc[[2, 1, 0, 5, 4, 3]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_timesteps_differ_between_blocks(self):
+        index = pd.MultiIndex.from_tuples([(0, 0), (0, 1), (1, 0), (1, 5)])
+        data = pd.DataFrame(
+            np.arange(8.0).reshape(4, 2), index=index, columns=["a", "b"]
+        )
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_uneven_blocks_that_divide_evenly(self):
+        """Block count divides the row count, but the blocks are not equal length."""
+        clusters = [0] * 2 + [1] * 4 + [2] * 6
+        index = pd.MultiIndex.from_arrays([clusters, range(12)])
+        data = pd.DataFrame(
+            np.arange(24.0).reshape(12, 2), index=index, columns=["a", "b"]
+        )
+        assert _expand_periods_fast(data, (0, 1, 2)) is None
+
+    def test_unknown_cluster_assignment(self):
+        data = _grid((0, 1), n_timesteps=3)
+        assert _expand_periods_fast(data, (0, 9)) is None
+
+    def test_unknown_cluster_assignment_with_gapped_labels(self):
+        """Non-identity labels go through get_indexer, which must reject strays."""
+        data = _grid((0, 3, 7), n_timesteps=3)
+        assert _expand_periods_fast(data, (0, 9)) is None
+
+    def test_fallback_still_produces_correct_values(self):
+        """A declined input still round-trips through _expand_periods."""
+        data = _grid((0, 1), n_timesteps=3).astype("Float64")
+        expanded = _expand_periods(data, (1, 0))
+        assert expanded.shape == (6, 3)
+        np.testing.assert_allclose(
+            expanded.to_numpy(dtype=float),
+            np.vstack(
+                [data.loc[1].to_numpy(dtype=float), data.loc[0].to_numpy(dtype=float)]
+            ),
+        )
+
+
+def _segment_grid(clusters, durations, n_columns=3, seed=0):
+    """Build a segment-level frame plus its matching durations, sorted-ID keyed."""
+    rng = np.random.default_rng(seed)
+    n_segments = len(durations[0])
+    index = pd.MultiIndex.from_product([clusters, range(n_segments)])
+    values = rng.random((len(index), n_columns))
+    data = pd.DataFrame(
+        values, index=index, columns=[f"c{i}" for i in range(n_columns)]
+    )
+    return data, tuple(durations)
+
+
+class TestExpandSegmentsFastPath:
+    """The scatter must match the per-cluster pandas loop exactly."""
+
+    @pytest.mark.parametrize(
+        ("clusters", "durations"),
+        [
+            ((0, 1), ((2, 3), (1, 4))),
+            ((0,), ((5,),)),
+            ((0, 4, 9), ((1, 1, 3), (2, 2, 1), (3, 1, 1))),
+            ((2, 0, 1), ((1, 4), (3, 2), (2, 3))),
+        ],
+        ids=["two-clusters", "single-segment", "gapped-labels", "unsorted-labels"],
+    )
+    def test_matches_pandas_path(self, clusters, durations):
+        data, durations = _segment_grid(clusters, durations)
+        fast = _expand_segments_fast(data, durations)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_segments_pandas(data, durations))
+
+    def test_durations_are_keyed_by_sorted_cluster_id(self):
+        """Unsorted index labels must still pick each cluster's own durations."""
+        data, durations = _segment_grid((2, 0, 1), ((1, 4), (3, 2), (2, 3)))
+        fast = _expand_segments_fast(data, durations)
+        assert fast is not None
+        # Cluster 0 is first in sorted order, so it gets durations (1, 4):
+        # values land at timesteps 0 and 1, and nowhere else.
+        cluster_0 = fast.loc[0]
+        assert cluster_0.notna().all(axis=1).tolist() == [
+            True,
+            True,
+            False,
+            False,
+            False,
+        ]
+
+    def test_zero_duration_segment_is_overwritten(self):
+        """A zero-length segment shares a start; the later value wins, as in the loop."""
+        data, durations = _segment_grid((0, 1), ((0, 3), (1, 2)))
+        fast = _expand_segments_fast(data, durations)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_segments_pandas(data, durations))
+
+
+class TestExpandSegmentsFallback:
+    """Inputs the segment fast path must decline."""
+
+    def test_mixed_dtypes(self):
+        data, durations = _segment_grid((0, 1), ((2, 3), (1, 4)))
+        data["c0"] = data["c0"].astype("float32")
+        assert _expand_segments_fast(data, durations) is None
+
+    def test_extension_dtype(self):
+        data, durations = _segment_grid((0, 1), ((2, 3), (1, 4)))
+        assert _expand_segments_fast(data.astype("Float64"), durations) is None
+
+    def test_uneven_period_lengths(self):
+        """Clusters whose segments sum to different period lengths."""
+        data, durations = _segment_grid((0, 1), ((2, 3), (1, 1)))
+        assert _expand_segments_fast(data, durations) is None
+
+    def test_duration_count_mismatch(self):
+        data, _ = _segment_grid((0, 1), ((2, 3), (1, 4)))
+        assert _expand_segments_fast(data, ((2, 3),)) is None
+
+    def test_ragged_durations(self):
+        data, _ = _segment_grid((0, 1), ((2, 3), (1, 4)))
+        assert _expand_segments_fast(data, ((5,), (1, 4))) is None
+
+    def test_irregular_index(self):
+        data, durations = _segment_grid((0, 1), ((2, 3), (1, 4)))
+        assert _expand_segments_fast(data.iloc[[0, 2, 1, 3]], durations) is None


### PR DESCRIPTION
**Draft.** Stacked on #449. One change, measured against it. Addresses #432.

`ClusteringResult.disaggregate()` expanded typical-period data back onto the full time index by round-tripping through `unstack`/`stack`, rebuilding a MultiIndex on every call. Expansion is a gather: each original timestep already knows which typical period and timestep it maps to, so the result is one fancy-index into an array. `_expand_periods` and the segment expansion now do that directly, and input validation stops rebuilding frames to check shapes.

## Affects

`ClusteringResult.disaggregate()` and `AggregationResult.disaggregate()` — the caller-invoked expansion of external results. **Not** the reconstruction of the input, which is eager inside `aggregate()` and takes a different path.

Like `accuracy` in #449, this is code an `aggregate()`-only benchmark never touches — which is why the headroom was there to find.

## Isolated effect

| benchmark | before | after | |
|---|---:|---:|---:|
| `test_disaggregate[wide_segmented]` (36 clusters x 20 col, 12 seg) | 8.11 ms | 0.48 ms | **−94.0%** (17x) |
| `test_disaggregate[wide]` (36 clusters x 20 col) | 3.32 ms | 0.25 ms | **−92.5%** (13x) |
| `test_disaggregate[small]` (8 clusters x 4 col) | 2.30 ms | 0.20 ms | **−91.2%** (11x) |

The segmented path gains most because it expanded twice — segments to timesteps, then periods to the full index.

## Workflow effect

The largest in the batch, because this is the one cost that **multiplies rather than amortises**: an optimization run calls it once per solved variable.

| workflow | before | after | |
|---|---:|---:|---:|
| `optimization_roundtrip[segments]` (50 variables) | 464.54 ms | 84.81 ms | **−81.7%** (5.5x) |
| `optimization_roundtrip[typical_periods]` (50 variables) | 189.39 ms | 39.29 ms | **−79.3%** (4.8x) |

Workflows that never call `disaggregate()` sat inside the noise floor.

<details><summary>Workflow code (<code>benchmarks/test_workflows.py</code>, added in #443)</summary>

```python
@pytest.mark.benchmark(group="workflow")
@pytest.mark.parametrize("resolution", ["typical_periods", "segments"])
def test_workflow_optimization_roundtrip(benchmark, resolution):
    """Cluster once, solve on the typical periods, expand every variable back.

    The shape of an optimization run: the solver returns one value per
    (typical period, timestep) for each of its variables, and every one of
    them has to be mapped back onto the original time index before the result
    means anything. Only the expansion repeats per variable. Segmented results
    expand through a different path than unsegmented ones, so both run here.
    """
    profiles = pd.read_csv(WIDE_CSV, index_col=0, parse_dates=True)
    profiles = pd.concat([profiles.add_suffix(f"_{i}") for i in range(5)], axis=1).iloc[
        :, :20
    ]
    segments = SegmentConfig(n_segments=12) if resolution == "segments" else None
    n_variables = 50
    benchmark.extra_info["n_variables"] = n_variables

    def run():
        result = aggregate(profiles, 36, segments=segments)
        solved_variables = result.cluster_representatives
        return [result.disaggregate(solved_variables) for _ in range(n_variables)]

    benchmark.pedantic(run, **HEAVY)
```
</details>

## Measurement protocol

Arms interleaved within each repetition; **minimum** across four runs, since contention only ever adds time. Noise floor about ±5%, so nothing smaller is claimed. Workflows whose setup is `kmeans_mean` are excluded from the quoted figures — multithreaded scikit-learn makes them swing up to ~20% run to run. macOS arm64, Python 3.12, numpy 2.5.1 / pandas 3.0.5 / scikit-learn 1.8.0 / scipy 1.17.0.

## Equivalence

Full test suite green — **728 passed** at this level, including **33 new tests** (241 lines) covering the expansion directly: unsegmented and segmented, with and without extreme periods, and against externally supplied frames whose column order differs from the clustering's.

## Reviewer note

By some margin the largest change in the batch — +540/−36 across `result.py` and its tests, against +14 to +35 for the other two — and it carries the largest claim. It is also the best tested of the three. If review effort is rationed, spend it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
