### PR TITLE
perf: cache the cluster id set for disaggregate validation

### DIFF
--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -561,8 +561,10 @@ def _validate_disaggregate_input(
         data = data.droplevel(list(range(2, data.index.nlevels)))
 
     # Validate cluster IDs
-    data_clusters = set(data.index.get_level_values(0).unique())
-    expected_clusters = set(clustering.cluster_assignments)
+    cluster_level = data.index.get_level_values(0)
+    unique_clusters = cluster_level.unique()
+    data_clusters = set(unique_clusters)
+    expected_clusters = clustering._cluster_id_set
     if data_clusters != expected_clusters:
         missing = expected_clusters - data_clusters
         extra = data_clusters - expected_clusters
@@ -585,12 +587,15 @@ def _validate_disaggregate_input(
         expected = clustering.n_timesteps_per_period
         kind = "timesteps"
 
-    for cluster in data.index.get_level_values(0).unique():
-        n_in_cluster = len(data.loc[cluster])
-        if n_in_cluster != expected:
-            raise ValueError(
-                f"cluster {cluster} has {n_in_cluster} {kind}, expected {expected}"
-            )
+    counts = cluster_level.value_counts()
+    mismatched = counts[counts != expected]
+    if len(mismatched):
+        # Report the first offending cluster in index order, as a row-wise scan would.
+        cluster = next(c for c in unique_clusters if c in mismatched.index)
+        raise ValueError(
+            f"cluster {cluster} has {int(mismatched[cluster])} {kind}, "
+            f"expected {expected}"
+        )
 
     return data
 
@@ -896,10 +901,15 @@ class ClusteringResult:
 
         return tuple(assignments_list), tuple(durations_list), centers
 
+    @cached_property
+    def _cluster_id_set(self) -> frozenset[int]:
+        """Distinct cluster IDs, cached so repeated disaggregation stays cheap."""
+        return frozenset(self.cluster_assignments)
+
     @property
     def n_clusters(self) -> int:
         """Number of clusters (typical periods)."""
-        return len(set(self.cluster_assignments))
+        return len(self._cluster_id_set)
 
     @property
     def n_original_periods(self) -> int:


### PR DESCRIPTION
**Draft.** Targets `develop` directly. First of three split out of a single 540-line change, so each can be reviewed on its own; #452 and #453 stack on top of this one. Measured against the suite in #443.

`_validate_disaggregate_input` rebuilt the set of expected cluster ids from `cluster_assignments` on every call, then walked the supplied frame cluster by cluster with `data.loc[cluster]` purely to count rows — one pandas selection per cluster, each materialising a sub-frame that is discarded.

The expected ids become a `cached_property`; the per-cluster counts come from one `value_counts()`.

## Affects

`ClusteringResult.disaggregate()` and `AggregationResult.disaggregate()` — validation runs once per call, so an optimization run pays it per solved variable.

The raised error is unchanged, **including which cluster it names first**: the offending cluster is still reported in index order, as the row-wise scan did.

## Effect — and where it does *not* apply

| benchmark | before | after | |
|---|---:|---:|---:|
| `test_disaggregate[wide]` (36 clusters x 20 col) | 3.3 ms | 2.4 ms | **−29.3%** |
| `test_disaggregate[wide_segmented]` | 8.2 ms | 7.1 ms | −13.2% |
| `test_disaggregate[small]` (8 clusters x 4 col) | 2.3 ms | 2.1 ms | −8.8% |
| `test_disaggregate[production]` (40 clusters x 400 col, 2 y) | 29.1 ms | 28.7 ms | −1.4% |
| `test_disaggregate[production_segmented]` | 35.7 ms | 34.8 ms | −2.4% |

**This removes a roughly fixed ~1 ms cost, not a scaling one.** It is 29% of a medium call and under 3% of a production one, because the expansion itself grows with output size while validation does not. Quoting only the −29% would misrepresent it.

| workflow | before | after | |
|---|---:|---:|---:|
| `optimization_roundtrip[typical_periods]` (50 vars, 20 col) | 201.1 ms | 143.7 ms | **−28.6%** |
| `optimization_roundtrip[segments]` | 483.7 ms | 429.7 ms | −11.2% |
| `optimization_roundtrip_production[segments]` (20 vars, 400 col, 2 y) | 1732 ms | 1603 ms | −7.5% |
| `optimization_roundtrip_production[typical_periods]` | 1334 ms | 1368 ms | +2.6% (noise) |

The honest summary: worthwhile for models with many variables at moderate width, marginal at production width. It is also 28 lines and independent of the two PRs above it, so it costs little to take.

<details><summary>Workflow code (<code>benchmarks/test_workflows.py</code>, added in #443)</summary>

```python
@pytest.mark.benchmark(group="workflow")
@pytest.mark.parametrize("resolution", ["typical_periods", "segments"])
def test_workflow_optimization_roundtrip(benchmark, resolution):
    """Cluster once, solve on the typical periods, expand every variable back.

    The shape of an optimization run: the solver returns one value per
    (typical period, timestep) for each of its variables, and every one of
    them has to be mapped back onto the original time index before the result
    means anything. Only the expansion repeats per variable. Segmented results
    expand through a different path than unsegmented ones, so both run here.
    """
    profiles = pd.read_csv(WIDE_CSV, index_col=0, parse_dates=True)
    profiles = pd.concat([profiles.add_suffix(f"_{i}") for i in range(5)], axis=1).iloc[
        :, :20
    ]
    segments = SegmentConfig(n_segments=12) if resolution == "segments" else None
    n_variables = 50
    benchmark.extra_info["n_variables"] = n_variables

    def run():
        result = aggregate(profiles, 36, segments=segments)
        solved_variables = result.cluster_representatives
        return [result.disaggregate(solved_variables) for _ in range(n_variables)]

    benchmark.pedantic(run, **HEAVY)
```
</details>

## Measurement protocol

Arms interleaved within each repetition; **minimum** across runs, since contention only ever adds time. Noise floor about ±5% relative, but on sub-millisecond benchmarks absolute noise (~±0.05 ms) dominates, so percentages there are not meaningful. macOS arm64, Python 3.12, numpy 2.5.1 / pandas 3.0.5 / scikit-learn 1.8.0 / scipy 1.17.0.

## Equivalence

Full test suite green (695 passed). No new tests: the existing black-box coverage in `test/test_disaggregate.py` — including `TestDisaggregateValidation`, which asserts the error message — already pins this behaviour.

**+19/−9, one file.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

