### PR TITLE
perf: expand typical periods with a numpy gather

### DIFF
--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -6,7 +6,7 @@ import math
 import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import numpy as np
 import pandas as pd
@@ -600,6 +600,209 @@ def _validate_disaggregate_input(
     return data
 
 
+class _PeriodGrid(NamedTuple):
+    """A regular ``(cluster, inner)`` index laid out as equal contiguous blocks.
+
+    Attributes:
+        labels: Cluster label of each block, in index order.
+        block_size: Rows per block — timesteps per period, or segments per
+            period for segment-level data.
+    """
+
+    labels: np.ndarray
+    block_size: int
+
+
+def _uniform_numpy_dtype(data: pd.DataFrame) -> np.dtype | None:
+    """The one numpy dtype shared by every column, or None if there isn't one.
+
+    A frame with a single dtype has values that reshape as one block, which is
+    what the numpy fast paths need. Mixed dtypes and pandas extension dtypes
+    (which have no numpy equivalent) return None.
+
+    Args:
+        data: Frame to inspect.
+
+    Returns:
+        The shared dtype, or None if the columns disagree, are extension
+        dtypes, or there are no columns at all.
+    """
+    dtypes = data.dtypes.to_numpy()
+    if len(dtypes) == 0 or not isinstance(dtypes[0], np.dtype):
+        return None
+    if not (dtypes == dtypes[0]).all():
+        return None
+    return cast("np.dtype", dtypes[0])
+
+
+def _period_grid(index: pd.MultiIndex) -> _PeriodGrid | None:
+    """Describe ``index`` as a regular period grid, or None if it is irregular.
+
+    A regular grid gives every cluster one contiguous block of equal length,
+    each block carrying the same ascending inner labels — the layout of every
+    typical-period frame tsam produces. On such a grid, expanding periods is a
+    gather along the cluster axis rather than an unstack/stack round trip.
+
+    Args:
+        index: Two-level ``(cluster, timestep)`` or ``(cluster, segment)``
+            MultiIndex.
+
+    Returns:
+        The grid description, or None if the layout is irregular.
+    """
+    n_rows = len(index)
+    clusters = index.get_level_values(0).to_numpy()
+    is_block_start = np.concatenate(([True], clusters[1:] != clusters[:-1]))
+    starts = np.flatnonzero(is_block_start)
+    n_blocks = len(starts)
+    if n_blocks == 0 or n_rows % n_blocks:
+        return None
+
+    block_size = n_rows // n_blocks
+    if not np.array_equal(starts, np.arange(n_blocks) * block_size):
+        return None
+
+    labels = clusters[starts]
+    if not pd.Index(labels).is_unique:
+        return None
+
+    inner = index.get_level_values(1).to_numpy().reshape(n_blocks, block_size)
+    if not (inner == inner[0]).all():
+        return None
+    # unstack() sorts the inner level, so only ascending blocks expand identically.
+    first_block = pd.Index(inner[0])
+    if not (first_block.is_monotonic_increasing and first_block.is_unique):
+        return None
+
+    return _PeriodGrid(labels=labels, block_size=block_size)
+
+
+def _block_positions(
+    block_labels: np.ndarray,
+    cluster_assignments: tuple[int, ...],
+) -> np.ndarray | None:
+    """Positions in ``block_labels`` for each assigned cluster, or None if unknown.
+
+    Args:
+        block_labels: Cluster label of each block, in index order.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Integer positions to gather, or None if any assignment is not a known
+        block label.
+    """
+    assignments = np.asarray(cluster_assignments)
+    n_blocks = len(block_labels)
+    labels_are_positions = block_labels.dtype.kind in "iu" and np.array_equal(
+        block_labels, np.arange(n_blocks)
+    )
+    if not labels_are_positions:
+        positions = pd.Index(block_labels).get_indexer(pd.Index(assignments))
+        return None if (positions < 0).any() else positions
+
+    # The usual case: clusters are labelled 0..n-1, so the labels are positions.
+    if assignments.dtype.kind not in "iu":
+        return None
+    if not ((assignments >= 0) & (assignments < n_blocks)).all():
+        return None
+    return assignments
+
+
+def _expand_periods(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame:
+    """Expand typical-period data to original time series length.
+
+    Selects rows from ``data`` according to ``cluster_assignments``, mapping
+    each original period to its cluster representative.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with integer index, one row per original timestep.
+    """
+    fast = _expand_periods_fast(data, cluster_assignments)
+    if fast is not None:
+        return fast
+    return _expand_periods_pandas(data, cluster_assignments)
+
+
+def _expand_periods_fast(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame | None:
+    """Expand periods by gathering rows in numpy, or None if not applicable.
+
+    Applies on a regular period grid whose columns share one numpy dtype.
+    Anything else (irregular grid, mixed or extension dtypes, unknown cluster
+    labels) returns None and the caller falls back to the pandas path.
+
+    The gather writes into a pre-transposed buffer so the result can be wrapped
+    without copying while keeping pandas' native column-major block layout.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with a RangeIndex, or None if the fast path does not apply.
+    """
+    dtype = _uniform_numpy_dtype(data)
+    if dtype is None:
+        return None
+
+    grid = _period_grid(data.index)  # type: ignore[arg-type]
+    if grid is None:
+        return None
+
+    positions = _block_positions(grid.labels, cluster_assignments)
+    if positions is None:
+        return None
+
+    n_columns = data.shape[1]
+    n_periods = len(positions)
+    n_rows = n_periods * grid.block_size
+
+    source = data.to_numpy().T.reshape(n_columns, len(grid.labels), grid.block_size)
+    gathered = np.empty((n_columns, n_periods, grid.block_size), dtype=dtype)
+    np.take(source, positions, axis=1, out=gathered)
+
+    return pd.DataFrame(
+        gathered.reshape(n_columns, n_rows).T,
+        index=pd.RangeIndex(n_rows),
+        columns=data.columns,
+        copy=False,
+    )
+
+
+def _expand_periods_pandas(
+    data: pd.DataFrame,
+    cluster_assignments: tuple[int, ...],
+) -> pd.DataFrame:
+    """Expand periods via unstack/stack, for any index layout or dtype mix.
+
+    The general fallback behind :func:`_expand_periods_fast`.
+
+    Args:
+        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
+        cluster_assignments: Cluster assignment for each original period.
+
+    Returns:
+        Flat DataFrame with integer index, one row per original timestep.
+    """
+    unstacked = data.unstack(level=1)  # rows=cluster, cols=(col, timestep)
+    expanded = unstacked.loc[list(cluster_assignments)]
+    expanded.index = range(len(cluster_assignments))
+    # Use level=-1 to always stack the timestep level (last), which is correct
+    # even when the original columns are a MultiIndex.
+    result: pd.DataFrame = expanded.stack(future_stack=True, level=-1)  # type: ignore[assignment]
+    result.index = pd.RangeIndex(len(result))
+    return result
+
+
 def _expand_segments_to_timesteps(
     data: pd.DataFrame,
     segment_durations: tuple[tuple[int, ...], ...],
@@ -641,32 +844,6 @@ def _expand_segments_to_timesteps(
         parts.append(pd.DataFrame(values, index=idx, columns=data.columns))
 
     return cast("pd.DataFrame", pd.concat(parts))
-
-
-def _expand_periods(
-    data: pd.DataFrame,
-    cluster_assignments: tuple[int, ...],
-) -> pd.DataFrame:
-    """Expand typical-period data to original time series length.
-
-    Selects rows from ``data`` according to ``cluster_assignments``, mapping
-    each original period to its cluster representative.
-
-    Args:
-        data: Typical-period data with ``(cluster, timestep)`` MultiIndex.
-        cluster_assignments: Cluster assignment for each original period.
-
-    Returns:
-        Flat DataFrame with integer index, one row per original timestep.
-    """
-    unstacked = data.unstack(level=1)  # rows=cluster, cols=(col, timestep)
-    expanded = unstacked.loc[list(cluster_assignments)]
-    expanded.index = range(len(cluster_assignments))
-    # Use level=-1 to always stack the timestep level (last), which is correct
-    # even when the original columns are a MultiIndex.
-    result: pd.DataFrame = expanded.stack(future_stack=True, level=-1)  # type: ignore[assignment]
-    result.index = pd.RangeIndex(len(result))
-    return result
 
 
 @dataclass(frozen=True)

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -8,6 +8,11 @@ import pytest
 
 from conftest import TESTDATA_CSV
 from tsam import ClusteringResult, SegmentConfig, aggregate
+from tsam.result import (
+    _expand_periods,
+    _expand_periods_fast,
+    _expand_periods_pandas,
+)
 
 
 @pytest.fixture
@@ -399,3 +404,152 @@ class TestDisaggregateValidation:
         wrong = result.cluster_representatives.iloc[::2]
         with pytest.raises(ValueError, match="timesteps"):
             result.clustering.disaggregate(wrong)
+
+
+def _grid(clusters, n_timesteps, n_columns=3, dtype=float, columns=None, seed=0):
+    """Build a typical-period frame on a regular (cluster, timestep) grid."""
+    rng = np.random.default_rng(seed)
+    index = pd.MultiIndex.from_product(
+        [clusters, range(n_timesteps)], names=["cluster", "timestep"]
+    )
+    if columns is None:
+        columns = [f"c{i}" for i in range(n_columns)]
+    values = rng.random((len(index), len(columns)))
+    return pd.DataFrame(values.astype(dtype), index=index, columns=columns)
+
+
+class TestExpandPeriodsFastPath:
+    """The numpy gather must match the pandas fallback exactly (issue #432)."""
+
+    @pytest.mark.parametrize(
+        ("clusters", "assignments"),
+        [
+            ((0, 1, 2), (0, 2, 1, 1, 0)),
+            ((0,), (0, 0, 0)),
+            ((0, 3, 7), (7, 0, 3, 7, 7, 0)),
+            ((2, 0, 1), (0, 1, 2, 2, 0)),
+            ((0, 1, 2, 3), (3, 3, 3, 3)),
+        ],
+        ids=[
+            "contiguous",
+            "single",
+            "gapped-labels",
+            "unsorted-labels",
+            "one-repeated",
+        ],
+    )
+    def test_matches_pandas_path(self, clusters, assignments):
+        data = _grid(clusters, n_timesteps=4)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_multiindex_columns(self):
+        columns = pd.MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 1)])
+        data = _grid((0, 1, 2), n_timesteps=4, columns=columns)
+        assignments = (2, 0, 1, 2)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_nan_values_preserved(self):
+        """Segment expansion leaves NaN between segment starts."""
+        data = _grid((0, 1), n_timesteps=4)
+        data.iloc[1:3] = np.nan
+        assignments = (1, 0, 1)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_single_column_and_row_shapes(self):
+        data = _grid((0, 1), n_timesteps=1, n_columns=1)
+        assignments = (1, 1, 0)
+        fast = _expand_periods_fast(data, assignments)
+        assert fast is not None
+        assert fast.shape == (3, 1)
+        pd.testing.assert_frame_equal(fast, _expand_periods_pandas(data, assignments))
+
+    def test_result_uses_native_block_layout(self):
+        """Guard against handing back a transposed block, which slows every consumer."""
+        data = _grid((0, 1, 2), n_timesteps=24, n_columns=8)
+        fast = _expand_periods_fast(data, (0, 1, 2, 1, 0))
+        assert fast is not None
+        block = fast._mgr.blocks[0].values
+        assert block.shape == (8, 5 * 24)
+        assert block.flags.c_contiguous
+
+
+class TestExpandPeriodsFallback:
+    """Inputs the fast path must decline, leaving the pandas implementation."""
+
+    def test_mixed_dtypes(self):
+        data = _grid((0, 1), n_timesteps=3)
+        data["c0"] = data["c0"].astype("float32")
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_extension_dtype(self):
+        data = _grid((0, 1), n_timesteps=3).astype("Float64")
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_no_columns(self):
+        data = _grid((0, 1), n_timesteps=3).iloc[:, :0]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_unequal_block_sizes(self):
+        data = _grid((0, 1), n_timesteps=3).drop((1, 2))
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_noncontiguous_cluster_blocks(self):
+        """Same cluster appearing in two separate blocks is not a regular grid."""
+        data = _grid((0, 1), n_timesteps=2)
+        data = data.iloc[[0, 2, 1, 3]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_unsorted_timesteps_within_block(self):
+        """unstack() sorts timesteps, so the gather must decline unsorted blocks."""
+        data = _grid((0, 1), n_timesteps=3)
+        data = data.iloc[[2, 1, 0, 3, 4, 5]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_descending_timesteps_in_every_block(self):
+        """Blocks agree but run backwards; unstack() would reorder them, so decline."""
+        data = _grid((0, 1), n_timesteps=3)
+        data = data.iloc[[2, 1, 0, 5, 4, 3]]
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_timesteps_differ_between_blocks(self):
+        index = pd.MultiIndex.from_tuples([(0, 0), (0, 1), (1, 0), (1, 5)])
+        data = pd.DataFrame(
+            np.arange(8.0).reshape(4, 2), index=index, columns=["a", "b"]
+        )
+        assert _expand_periods_fast(data, (0, 1)) is None
+
+    def test_uneven_blocks_that_divide_evenly(self):
+        """Block count divides the row count, but the blocks are not equal length."""
+        clusters = [0] * 2 + [1] * 4 + [2] * 6
+        index = pd.MultiIndex.from_arrays([clusters, range(12)])
+        data = pd.DataFrame(
+            np.arange(24.0).reshape(12, 2), index=index, columns=["a", "b"]
+        )
+        assert _expand_periods_fast(data, (0, 1, 2)) is None
+
+    def test_unknown_cluster_assignment(self):
+        data = _grid((0, 1), n_timesteps=3)
+        assert _expand_periods_fast(data, (0, 9)) is None
+
+    def test_unknown_cluster_assignment_with_gapped_labels(self):
+        """Non-identity labels go through get_indexer, which must reject strays."""
+        data = _grid((0, 3, 7), n_timesteps=3)
+        assert _expand_periods_fast(data, (0, 9)) is None
+
+    def test_fallback_still_produces_correct_values(self):
+        """A declined input still round-trips through _expand_periods."""
+        data = _grid((0, 1), n_timesteps=3).astype("Float64")
+        expanded = _expand_periods(data, (1, 0))
+        assert expanded.shape == (6, 3)
+        np.testing.assert_allclose(
+            expanded.to_numpy(dtype=float),
+            np.vstack(
+                [data.loc[1].to_numpy(dtype=float), data.loc[0].to_numpy(dtype=float)]
+            ),
+        )


### PR DESCRIPTION
**Draft.** Stacked on #451. Second of three, and the one that carries the batch.

`_expand_periods` mapped each original period to its cluster representative by unstacking the frame to one row per cluster, selecting with `.loc`, then stacking back — rebuilding a MultiIndex twice per call to perform what is a gather. Every original timestep already knows which cluster and which timestep within it to read, so the result is one fancy-index into the values.

## Affects

The **unsegmented** expansion inside `disaggregate()`. Segmented results keep the old segment step until #453.

The fast path applies only when the supplied frame is a regular `(cluster, inner)` grid of equal contiguous blocks in a single numpy dtype — decided by `_period_grid` and `_uniform_numpy_dtype`. Anything else takes `_expand_periods_pandas`, the previous implementation unchanged.

That fallback is **not hypothetical**: unlike the input reconstruction, `disaggregate()` receives a *caller-supplied* frame — optimization results — so its dtypes and layout are not tsam's to guarantee. About a third of this diff is the fallback and the guards selecting it.

## Isolated effect

| benchmark | output size | before | after | |
|---|---|---:|---:|---:|
| `test_disaggregate[production]` (40 clusters x 400 col, 2 y) | **7.0 M cells** | 29.0 ms | 3.8 ms | **−86.9%** |
| `test_disaggregate[production_segmented]` | 7.0 M cells | 34.5 ms | 9.9 ms | **−71.2%** |
| `test_disaggregate[small]` | 35 K cells | 2.2 ms | 0.2 ms | **−90.6%** |
| `test_disaggregate[wide]` | 175 K cells | 2.4 ms | 0.3 ms | **−89.0%** |
| `test_disaggregate[wide_segmented]` | 175 K cells | 7.2 ms | 5.0 ms | −29.7% |

**The gain holds across three orders of magnitude of output size** — it is not a small-input artefact. The segmented rows gain only partially because they still expand segments through pandas first; that is what #453 fixes.

## Workflow effect

| workflow | before | after | |
|---|---:|---:|---:|
| `optimization_roundtrip[typical_periods]` (50 vars, 20 col) | 143.4 ms | 37.7 ms | **−73.7%** |
| `optimization_roundtrip_production[typical_periods]` (20 vars, 400 col, 2 y) | 1366 ms | 810 ms | **−40.7%** |
| `optimization_roundtrip_production[segments]` | 1601 ms | 1124 ms | **−29.8%** |
| `optimization_roundtrip[segments]` | 427.7 ms | 328.7 ms | −23.2% |

The production workflow gains 41% rather than 87% because it also runs `aggregate()` once, and clustering 400 columns over two years is most of what remains. The expansion is the part this removes.

<details><summary>Workflow code (<code>benchmarks/test_workflows.py</code>, added in #443)</summary>

```python
@pytest.mark.benchmark(group="workflow")
@pytest.mark.parametrize("resolution", ["typical_periods", "segments"])
def test_workflow_optimization_roundtrip(benchmark, resolution):
    """Cluster once, solve on the typical periods, expand every variable back.

    The shape of an optimization run: the solver returns one value per
    (typical period, timestep) for each of its variables, and every one of
    them has to be mapped back onto the original time index before the result
    means anything. Only the expansion repeats per variable. Segmented results
    expand through a different path than unsegmented ones, so both run here.
    """
    profiles = pd.read_csv(WIDE_CSV, index_col=0, parse_dates=True)
    profiles = pd.concat([profiles.add_suffix(f"_{i}") for i in range(5)], axis=1).iloc[
        :, :20
    ]
    segments = SegmentConfig(n_segments=12) if resolution == "segments" else None
    n_variables = 50
    benchmark.extra_info["n_variables"] = n_variables

    def run():
        result = aggregate(profiles, 36, segments=segments)
        solved_variables = result.cluster_representatives
        return [result.disaggregate(solved_variables) for _ in range(n_variables)]

    benchmark.pedantic(run, **HEAVY)
```
</details>

## Measurement protocol

Arms interleaved within each repetition; **minimum** across runs, since contention only ever adds time. Noise floor about ±5% relative, but on sub-millisecond benchmarks absolute noise (~±0.05 ms) dominates, so percentages there are not meaningful. macOS arm64, Python 3.12, numpy 2.5.1 / pandas 3.0.5 / scikit-learn 1.8.0 / scipy 1.17.0.

## Equivalence

Full test suite green (716 passed), including **21 new tests** in `TestExpandPeriodsFastPath` and `TestExpandPeriodsFallback` asserting the two paths agree and that the guards reject mixed dtypes and irregular grids.

**src +204/−27, tests +154.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
