### PR TITLE
perf(segmentation): build the segment frame once, from a stacked array

### DIFF
--- a/src/tsam/algorithms/segmentation.py
+++ b/src/tsam/algorithms/segmentation.py
@@ -212,17 +212,17 @@ def segmentation(
                     segment_center_indices[c] for c in cluster_order_unique
                 ]
 
+        # stacked first: pandas sanitizes a list of arrays column by column
+        segment_values = pd.DataFrame(
+            np.asarray(cluster_centers), columns=normalized_typical_periods.columns
+        )
         # predict each time step of the period by representing it with the corresponding segment's values
-        predicted_segmented = (
-            pd.DataFrame(cluster_centers, columns=normalized_typical_periods.columns)
-            .reindex(cluster_order)
-            .reset_index(drop=True)
+        predicted_segmented = segment_values.reindex(cluster_order).reset_index(
+            drop=True
         )
         # represent the period by the segments in the right order only instead of each time step
-        segmented_typical = (
-            pd.DataFrame(cluster_centers, columns=normalized_typical_periods.columns)
-            .reindex(cluster_order_unique)
-            .set_index(np.sort(indices))
+        segmented_typical = segment_values.reindex(cluster_order_unique).set_index(
+            np.sort(indices)
         )
         # keep additional information on the lengths of the segments in the right order
         segment_duration = (


### PR DESCRIPTION
`representations()` returns the segment values as a **list of 1-D arrays**, and the per-period loop in `segmentation()` handed that list to `pd.DataFrame` twice. Pandas sanitizes a list of arrays column by column; the same data as a 2-D array is taken as one block.

The fix stacks once with `np.asarray` and reindexes the resulting frame for both views. It ran twice per typical period, so 80 constructions per `aggregate()` at 40 typical days.

Just that construction, in isolation (`timeit`, min of 7 x 500):

| | list of arrays | stacked | |
|---|---|---|---|
| 12 segments x 8 columns | 128 us | 15 us | 8.7x |
| 12 segments x 40 columns | 343 us | 13 us | 26x |
| 12 segments x 160 columns | 1069 us | 13 us | 84x |
| 24 segments x 40 columns | 381 us | 14 us | 28x |

The list form costs per column, the stacked form does not — which is what sets where this shows up and where it does not.

## Affects

- Any call that passes `segments=SegmentConfig(...)` — every representation, every clustering method.
- **Not** affected: runs without segmentation (the loop is never entered), and `apply()` / `disaggregate()`, which do not rebuild these frames.

## Numbers

Method: one warm process, both arms in the same interpreter — `develop`'s `segmentation` is loaded from a worktree as a function object and swapped in, so nothing but that function differs. Arm order flips every round so drift cancels. Min of 9 rounds (3 for the production case); the medians agree with the mins to within 0.02x throughout. macOS arm64.

**Workflows** — each reads back the fields the caller actually uses (`cluster_representatives`, `cluster_assignments`). FINE multi-regional example, 8760 x 40, unless noted:

| workflow | develop | this PR | |
|---|---|---|---|
| `aggregateTemporally()` defaults: 40 days, distribution, 12 segments, no rescale | 79.8 ms | **66.9 ms** | 1.19x |
| library default (hierarchical + medoid) + 12 segments | 82.1 ms | **69.6 ms** | 1.18x |
| hierarchical + mean + 12 segments | 79.4 ms | **65.2 ms** | 1.22x |
| distribution, 24 segments | 84.2 ms | **66.7 ms** | 1.26x |
| production: 320 columns x 2 years, global distribution, 12 segments | 3.72 s | **3.60 s** | 1.03x |
| 12-call tuning sweep, 4-column `testdata.csv`, 6 segments | 235 ms | 233 ms | 1.01x |
| *control:* same FINE job with no segmentation | 34.4 ms | 34.8 ms | 0.99x |

**`segmentation()` on its own** — 40 typical periods x 24 steps, mean representation unless noted:

| case | develop | this PR | |
|---|---|---|---|
| 8 columns, 12 segments | 34.9 ms | **31.1 ms** | 1.12x |
| 40 columns, 12 segments | 44.5 ms | **31.2 ms** | 1.42x |
| 160 columns, 12 segments | 80.7 ms | **32.5 ms** | 2.48x |
| 40 columns, 4 segments | 41.1 ms | **30.1 ms** | 1.37x |
| 40 columns, 24 segments | 47.9 ms | **31.9 ms** | 1.50x |
| 40 columns, 12 segments, distribution | 52.3 ms | **39.1 ms** | 1.34x |
| 8 periods, 40 columns, 12 segments | 9.1 ms | **6.4 ms** | 1.41x |

The gain grows with column count and is flat afterwards (31.2 -> 32.5 ms from 40 to 160 columns): what is left is the 40 scikit-learn ward fits, which this PR does not touch. On the FINE default job segmentation was ~63% of the call, of which only ~3.8 ms was those fits.

Two rows above are deliberately included as non-wins: the 4-column tuning sweep (1.01x — too few columns for a per-column cost to matter) and the no-segmentation control (0.99x — the loop never runs). The production case dilutes to 1.03x because clustering and the global duration fit dominate at 320 columns.

Reproduce with the workflow suite from #443:

```
pytest benchmarks/test_workflows.py --benchmark-only -k duration_segments
```

## Equivalence

Exactly equivalent — same values, same dtypes, same index. `695 passed, 145 skipped` locally, including the golden-value regression tests; and every case in the tables above compared its two arms frame-for-frame in the same process, all equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
