### PR TITLE
fix(extremes): transfer and cluster counts break when new_cluster empties a cluster

### DIFF
--- a/src/tsam/algorithms/clustering.py
+++ b/src/tsam/algorithms/clustering.py
@@ -11,6 +11,29 @@ if TYPE_CHECKING:
     from tsam.config import ClusterMethod, Distribution, MinMaxMean
 
 
+def _densify_labels(cluster_order: np.ndarray) -> np.ndarray:
+    """Renumber cluster labels onto ``0..n-1``, closing gaps left by empty clusters.
+
+    No clustering method promises to fill every cluster it was asked for.
+    k-maxoids on data with fewer distinct period shapes than clusters is the
+    plainest case: it leaves labels nobody uses, so the assignment comes back as
+    e.g. ``[0, 1, 3]`` for ``n_clusters=8``.
+
+    Cluster ids are positions everywhere downstream — representatives live in a
+    list indexed by id, and
+    :func:`~tsam.algorithms.representations.representations` returns one center
+    per *observed* label — so an unused label shifts every cluster above it and
+    leaves the highest one without a representative. Nothing is lost by dropping
+    it: a cluster with no members has no periods to compute a representative
+    from, and contributes nothing to the reconstruction.
+
+    Renumbering preserves order, so a label space that is already dense — every
+    method's normal outcome — comes back with its labels unchanged.
+    """
+    labels = np.unique(cluster_order)
+    return np.asarray(np.searchsorted(labels, cluster_order), dtype=int)
+
+
 def assign_clusters(
     candidates: np.ndarray,
     n_clusters: int,
@@ -27,7 +50,28 @@ def assign_clusters(
 
     Valid ``cluster_method`` values: 'averaging', 'kmeans', 'kmedoids',
     'kmaxoids', 'hierarchical', 'contiguous'.
+
+    Returns:
+        The cluster id of each period, as a dense label space: the ids run
+        ``0..n-1`` with no gaps, where ``n`` is the number of clusters that
+        actually received periods. That can be fewer than *n_clusters* — see
+        :func:`_densify_labels` for why the gaps are closed rather than kept.
     """
+    return _densify_labels(
+        _raw_assignment(
+            candidates, n_clusters, cluster_method, n_iter=n_iter, solver=solver
+        )
+    )
+
+
+def _raw_assignment(
+    candidates: np.ndarray,
+    n_clusters: int,
+    cluster_method: str,
+    n_iter: int = 100,
+    solver: str = "highs",
+) -> np.ndarray:
+    """Dispatch to the clustering method, returning its labels as it produced them."""
     if cluster_method == "averaging":
         n_sets = len(candidates)
         cluster_size = n_sets // n_clusters

--- a/src/tsam/algorithms/clustering.py
+++ b/src/tsam/algorithms/clustering.py
@@ -61,11 +61,14 @@ def assign_clusters(
         actually received periods. That can be fewer than *n_clusters* — see
         :func:`densify_labels` for why the gaps are closed rather than kept.
     """
-    return densify_labels(
-        _raw_assignment(
+    raw_cluster_order=_raw_assignment(
             candidates, n_clusters, cluster_method, n_iter=n_iter, solver=solver
         )
-    )
+    # Clustering configuration might yield non-dense cluster indices (e.g., when
+    # fewer clusters are needed due to duplicated periods). We reassign indices
+    # to be contiguous so downstream functions have a clear, well-defined data structure.
+    cluster_order= densify_labels(cluster_order=raw_cluster_order)
+    return cluster_order
 
 
 def _raw_assignment(

--- a/src/tsam/algorithms/clustering.py
+++ b/src/tsam/algorithms/clustering.py
@@ -20,12 +20,13 @@ def densify_labels(cluster_order: np.ndarray) -> np.ndarray:
     e.g. ``[0, 1, 3]`` for ``n_clusters=8``.
 
     Cluster ids are positions everywhere downstream — representatives live in a
-    list indexed by id, and
-    :func:`~tsam.algorithms.representations.representations` returns one center
-    per *observed* label — so an unused label shifts every cluster above it and
-    leaves the highest one without a representative. Nothing is lost by dropping
-    it: a cluster with no members has no periods to compute a representative
-    from, and contributes nothing to the reconstruction.
+    list indexed by id — so an unused label puts every cluster above it out of
+    step with its representative.
+    :func:`~tsam.algorithms.representations.representations` refuses such a
+    label space outright, which is why densifying happens here, before it is
+    called. Nothing is lost by dropping the label: a cluster with no members has
+    no periods to compute a representative from, and contributes nothing to the
+    reconstruction.
 
     Renumbering preserves order, so a label space that is already dense — every
     method's normal outcome — comes back with its labels unchanged.
@@ -61,13 +62,13 @@ def assign_clusters(
         actually received periods. That can be fewer than *n_clusters* — see
         :func:`densify_labels` for why the gaps are closed rather than kept.
     """
-    raw_cluster_order=_raw_assignment(
-            candidates, n_clusters, cluster_method, n_iter=n_iter, solver=solver
-        )
+    raw_cluster_order = _raw_assignment(
+        candidates, n_clusters, cluster_method, n_iter=n_iter, solver=solver
+    )
     # Clustering configuration might yield non-dense cluster indices (e.g., when
     # fewer clusters are needed due to duplicated periods). We reassign indices
     # to be contiguous so downstream functions have a clear, well-defined data structure.
-    cluster_order= densify_labels(cluster_order=raw_cluster_order)
+    cluster_order = densify_labels(cluster_order=raw_cluster_order)
     return cluster_order
 
 

--- a/src/tsam/algorithms/clustering.py
+++ b/src/tsam/algorithms/clustering.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tsam.config import ClusterMethod, Distribution, MinMaxMean
 
 
-def _densify_labels(cluster_order: np.ndarray) -> np.ndarray:
+def densify_labels(cluster_order: np.ndarray) -> np.ndarray:
     """Renumber cluster labels onto ``0..n-1``, closing gaps left by empty clusters.
 
     No clustering method promises to fill every cluster it was asked for.
@@ -55,9 +55,9 @@ def assign_clusters(
         The cluster id of each period, as a dense label space: the ids run
         ``0..n-1`` with no gaps, where ``n`` is the number of clusters that
         actually received periods. That can be fewer than *n_clusters* — see
-        :func:`_densify_labels` for why the gaps are closed rather than kept.
+        :func:`densify_labels` for why the gaps are closed rather than kept.
     """
-    return _densify_labels(
+    return densify_labels(
         _raw_assignment(
             candidates, n_clusters, cluster_method, n_iter=n_iter, solver=solver
         )

--- a/src/tsam/algorithms/clustering.py
+++ b/src/tsam/algorithms/clustering.py
@@ -30,8 +30,12 @@ def densify_labels(cluster_order: np.ndarray) -> np.ndarray:
     Renumbering preserves order, so a label space that is already dense — every
     method's normal outcome — comes back with its labels unchanged.
     """
-    labels = np.unique(cluster_order)
-    return np.asarray(np.searchsorted(labels, cluster_order), dtype=int)
+    # The labels actually in use, ascending and without duplicates.
+    used_labels = np.unique(cluster_order)
+    # A label's position in that sorted list is its new id: the lowest label
+    # becomes 0, the next becomes 1, and any gap between them closes.
+    new_ids = np.searchsorted(used_labels, cluster_order)
+    return np.asarray(new_ids, dtype=int)
 
 
 def assign_clusters(

--- a/src/tsam/algorithms/representations.py
+++ b/src/tsam/algorithms/representations.py
@@ -48,6 +48,12 @@ def representations(
         index of the original period chosen as each representative; ``None`` for
         the other methods.
 
+    Raises:
+        ValueError: If *cluster_order* leaves a label unused. One center is
+            returned per cluster, so a gap would renumber every cluster above it
+            — callers must densify first (see
+            :func:`~tsam.algorithms.clustering.densify_labels`).
+
     Note:
         Related helpers: mean_representation, medoid_representation,
         maxoid_representation, minmax_mean_representation.

--- a/src/tsam/algorithms/representations.py
+++ b/src/tsam/algorithms/representations.py
@@ -52,6 +52,14 @@ def representations(
         Related helpers: mean_representation, medoid_representation,
         maxoid_representation, minmax_mean_representation.
     """
+    labels = np.unique(np.asarray(cluster_order))
+    if labels.size and not np.array_equal(labels, np.arange(labels.size)):
+        raise ValueError(
+            f"cluster_order must use every label from 0 to {int(labels.max())}: "
+            f"one center is returned per cluster, so an unused label shifts every "
+            f"cluster above it and leaves the highest one without a center."
+        )
+
     cluster_center_indices = None
     if representation_method is None:
         representation_method = default

--- a/src/tsam/pipeline/clustering.py
+++ b/src/tsam/pipeline/clustering.py
@@ -242,6 +242,11 @@ def use_predefined_assignments(
     medoid periods (if center indices were saved) or recomputed from the new
     candidates under the same assignment.
 
+    This is the one path that does not run `assign_clusters`, so the stored
+    order is never densified. A label space with a gap is caught by
+    `representations` when centers are recomputed, but goes unchecked when
+    center indices were saved; `_drop_empty_clusters` closes it later.
+
     Args:
         candidates: Candidate period matrix for the new data.
         predef: Predefined assignments (``cluster_order`` and optional center

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -101,18 +101,27 @@ def _drop_empty_clusters(
 ) -> tuple[list[np.ndarray], np.ndarray, list[int], list[int] | None]:
     """Remove clusters that ended up representing no periods, and close the gap.
 
-    A hole in the label space can open at either end of this phase.
-    ``method="new_cluster"`` can absorb every member of a regular cluster; on
-    the transfer path a stored assignment can arrive with a hole already in it.
-    Cluster ids are positions downstream — representatives are looked up by id,
-    and `representations` returns one center per *observed* label — so a hole
-    misaligns every cluster above it. Nothing is lost by dropping it: a cluster
-    with no periods contributes nothing to the reconstruction, though the run
-    then returns fewer typical periods than ``n_clusters`` asked for.
+    An id can fall out of use at either end of this phase. Both
+    ``method="append"`` and ``method="new_cluster"`` move every extreme period
+    into a cluster of its own, so a small cluster whose members all turn out
+    extreme is left with nothing; ``new_cluster`` pulls neighbours away on top
+    of that. It takes a computed representation, though: an extreme whose
+    profile equals a center is skipped as redundant, so under ``medoid`` the
+    medoid member always stays behind. And on the transfer path a stored
+    assignment can arrive with an unused id already in it — that path skips
+    `assign_clusters`, so `densify_labels` never runs on it. A result this
+    pipeline produced cannot be holed, so that only happens for a hand-built or
+    hand-edited `ClusteringResult`.
 
-    Clustering itself is not a source of holes here: `assign_clusters` already
-    hands back a dense label space, so what this sees is what extremes did to
-    it.
+    Cluster ids are positions downstream, so an unused id has to go: an
+    interior one puts every cluster above it out of step with its
+    representative, and a trailing one leaves a center that surfaces as a
+    typical period representing no periods. Nothing is lost by dropping it,
+    though the run then returns fewer typical periods than ``n_clusters``
+    asked for.
+
+    Not sources: ``method="replace"`` edits centers without touching the
+    assignment, and clustering hands back a dense label space already.
 
     Returns:
         The inputs with empty clusters removed and every id renumbered, or the

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -119,14 +119,22 @@ def _drop_empty_clusters(
         inputs unchanged when no cluster is empty.
     """
     n_clusters = len(cluster_periods_list)
-    kept_ids = sorted({int(label) for label in np.asarray(cluster_order).ravel()})
-    if kept_ids and (kept_ids[0] < 0 or kept_ids[-1] >= n_clusters):
-        outside = [label for label in kept_ids if label < 0 or label >= n_clusters]
+
+    # The ids that still hold at least one period, ascending.
+    labels = np.asarray(cluster_order).ravel()
+    kept_ids = sorted({int(label) for label in labels})
+
+    # Every id below indexes cluster_periods_list, so one out of range means
+    # labels and representatives have gone out of step.
+    outside = [old_id for old_id in kept_ids if not 0 <= old_id < n_clusters]
+    if outside:
         raise ValueError(
             f"cluster_order holds labels outside range(0, {n_clusters}): "
             f"{outside}. Every label names a representative by position, so a "
             f"label without one can be neither kept nor dropped."
         )
+
+    # Already dense: nothing to drop, so hand the inputs straight back.
     if kept_ids == list(range(n_clusters)):
         return (
             cluster_periods_list,
@@ -135,25 +143,28 @@ def _drop_empty_clusters(
             cluster_center_indices,
         )
 
+    # Old id -> new id, for the structures that store ids rather than labels.
     renumbered = {old_id: new_id for new_id, old_id in enumerate(kept_ids)}
 
-    return (
-        [cluster_periods_list[old_id] for old_id in kept_ids],
-        # Same renumbering rule as the clustering stage, so both stages close a
-        # gap the same way; here it is the parallel structures below that make
-        # the difference, since only this stage has any.
-        densify_labels(cluster_order),
-        [renumbered[old_id] for old_id in extreme_cluster_idx],
-        # Center indices cover only the clusters clustering produced; the
-        # extremes get theirs appended later and always hold their own period.
-        None
-        if cluster_center_indices is None
-        else [
+    kept_periods = [cluster_periods_list[old_id] for old_id in kept_ids]
+
+    # Same renumbering rule as the clustering stage, so both close a gap the
+    # same way; the parallel structures are what make this stage different.
+    dense_order = densify_labels(cluster_order)
+
+    dense_extreme_idx = [renumbered[old_id] for old_id in extreme_cluster_idx]
+
+    # Center indices cover only the clusters clustering produced; the extremes
+    # get theirs appended later and always hold their own period.
+    kept_center_indices = None
+    if cluster_center_indices is not None:
+        kept_center_indices = [
             cluster_center_indices[old_id]
             for old_id in kept_ids
             if old_id < len(cluster_center_indices)
-        ],
-    )
+        ]
+
+    return kept_periods, dense_order, dense_extreme_idx, kept_center_indices
 
 
 def _representatives_to_dataframe(

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -100,21 +100,33 @@ def _drop_empty_clusters(
 ) -> tuple[list[np.ndarray], np.ndarray, list[int], list[int] | None]:
     """Remove clusters that ended up representing no periods, and close the gap.
 
-    ``method="new_cluster"`` can absorb every member of a regular cluster. Its
-    id would then leave a hole in the label space, and cluster ids are positions
-    downstream — representatives are looked up by id, and `representations`
-    returns one center per *observed* label — so a hole misaligns every cluster
-    above it. Nothing is lost by dropping it: a cluster with no periods
-    contributes nothing to the reconstruction, though the run then returns fewer
-    typical periods than ``n_clusters`` asked for.
+    A hole in the label space can open at either end of this phase.
+    ``method="new_cluster"`` can absorb every member of a regular cluster; on
+    the transfer path a stored assignment can arrive with a hole already in it.
+    Cluster ids are positions downstream — representatives are looked up by id,
+    and `representations` returns one center per *observed* label — so a hole
+    misaligns every cluster above it. Nothing is lost by dropping it: a cluster
+    with no periods contributes nothing to the reconstruction, though the run
+    then returns fewer typical periods than ``n_clusters`` asked for.
+
+    Clustering itself is not a source of holes here: `assign_clusters` already
+    hands back a dense label space, so what this sees is what extremes did to
+    it.
 
     Returns:
         The inputs with empty clusters removed and every id renumbered, or the
         inputs unchanged when no cluster is empty.
     """
     n_clusters = len(cluster_periods_list)
-    occupied = {int(label) for label in np.asarray(cluster_order).ravel()}
-    if len(occupied) == n_clusters:
+    kept_ids = sorted({int(label) for label in np.asarray(cluster_order).ravel()})
+    if kept_ids and (kept_ids[0] < 0 or kept_ids[-1] >= n_clusters):
+        outside = [label for label in kept_ids if label < 0 or label >= n_clusters]
+        raise ValueError(
+            f"cluster_order holds labels outside range(0, {n_clusters}): "
+            f"{outside}. Every label names a representative by position, so a "
+            f"label without one can be neither kept nor dropped."
+        )
+    if kept_ids == list(range(n_clusters)):
         return (
             cluster_periods_list,
             cluster_order,
@@ -122,7 +134,6 @@ def _drop_empty_clusters(
             cluster_center_indices,
         )
 
-    kept_ids = sorted(occupied)
     renumbered = {old_id: new_id for new_id, old_id in enumerate(kept_ids)}
 
     return (
@@ -510,6 +521,20 @@ def cluster_candidates(
         center[: prepared.n_feature_cols] for center in cluster_centers
     ]
 
+    # Clustering does not promise to fill every cluster it was asked for: with
+    # fewer distinct period shapes than clusters, some methods leave one empty.
+    # `assign_clusters` drops those so ids stay usable as positions, which makes
+    # the shortfall invisible unless it is said out loud.
+    if cfg.predef is None and len(cluster_periods_list) < cfg.n_clusters:
+        warnings.warn(
+            f"Clustering produced {len(cluster_periods_list)} non-empty clusters "
+            f"for the requested n_clusters={cfg.n_clusters}: "
+            f"'{cluster.method}' found fewer distinct period shapes than "
+            f"clusters, and empty clusters are dropped rather than kept as "
+            f"typical periods representing no periods. The aggregation is valid "
+            f"but returns fewer typical periods than requested."
+        )
+
     return ClusterAssignment(
         cluster_periods_list=cluster_periods_list,
         cluster_order=cluster_order,
@@ -585,20 +610,23 @@ def refine_representatives(
             cfg.extremes,
         )
         cluster_order = np.asarray(extended_order)
-        (
-            cluster_periods_list,
-            cluster_order,
-            extreme_cluster_idx,
-            cluster_center_indices,
-        ) = _drop_empty_clusters(
-            cluster_periods_list,
-            cluster_order,
-            extreme_cluster_idx,
-            cluster_center_indices,
-        )
     else:
         if cfg.predef is not None and cfg.predef.extreme_cluster_idx is not None:
             extreme_cluster_idx = list(cfg.predef.extreme_cluster_idx)
+
+    # Unconditional: extremes are one way to empty a cluster, not the only one,
+    # and every id below indexes into cluster_periods_list.
+    (
+        cluster_periods_list,
+        cluster_order,
+        extreme_cluster_idx,
+        cluster_center_indices,
+    ) = _drop_empty_clusters(
+        cluster_periods_list,
+        cluster_order,
+        extreme_cluster_idx,
+        cluster_center_indices,
+    )
 
     # Unweight all representatives (regular + extreme) — remove weights
     # before downstream steps (rescale, denorm) which expect unweighted data.

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -20,6 +20,7 @@ from typing import cast
 import numpy as np
 import pandas as pd
 
+from tsam.algorithms.clustering import densify_labels
 from tsam.config import Distribution, MinMaxMean
 from tsam.options import options
 from tsam.pipeline.accuracy import reconstruct
@@ -138,10 +139,10 @@ def _drop_empty_clusters(
 
     return (
         [cluster_periods_list[old_id] for old_id in kept_ids],
-        np.array(
-            [renumbered[int(label)] for label in np.asarray(cluster_order).ravel()],
-            dtype=int,
-        ),
+        # Same renumbering rule as the clustering stage, so both stages close a
+        # gap the same way; here it is the parallel structures below that make
+        # the difference, since only this stage has any.
+        densify_labels(cluster_order),
         [renumbered[old_id] for old_id in extreme_cluster_idx],
         # Center indices cover only the clusters clustering produced; the
         # extremes get theirs appended later and always hold their own period.

--- a/src/tsam/pipeline/orchestrator.py
+++ b/src/tsam/pipeline/orchestrator.py
@@ -92,6 +92,58 @@ def _count_occurrences(cluster_order: np.ndarray, n_clusters: int) -> dict[int, 
     return occurrences
 
 
+def _drop_empty_clusters(
+    cluster_periods_list: list[np.ndarray],
+    cluster_order: np.ndarray,
+    extreme_cluster_idx: list[int],
+    cluster_center_indices: list[int] | None,
+) -> tuple[list[np.ndarray], np.ndarray, list[int], list[int] | None]:
+    """Remove clusters that ended up representing no periods, and close the gap.
+
+    ``method="new_cluster"`` can absorb every member of a regular cluster. Its
+    id would then leave a hole in the label space, and cluster ids are positions
+    downstream — representatives are looked up by id, and `representations`
+    returns one center per *observed* label — so a hole misaligns every cluster
+    above it. Nothing is lost by dropping it: a cluster with no periods
+    contributes nothing to the reconstruction, though the run then returns fewer
+    typical periods than ``n_clusters`` asked for.
+
+    Returns:
+        The inputs with empty clusters removed and every id renumbered, or the
+        inputs unchanged when no cluster is empty.
+    """
+    n_clusters = len(cluster_periods_list)
+    occupied = {int(label) for label in np.asarray(cluster_order).ravel()}
+    if len(occupied) == n_clusters:
+        return (
+            cluster_periods_list,
+            cluster_order,
+            extreme_cluster_idx,
+            cluster_center_indices,
+        )
+
+    kept_ids = sorted(occupied)
+    renumbered = {old_id: new_id for new_id, old_id in enumerate(kept_ids)}
+
+    return (
+        [cluster_periods_list[old_id] for old_id in kept_ids],
+        np.array(
+            [renumbered[int(label)] for label in np.asarray(cluster_order).ravel()],
+            dtype=int,
+        ),
+        [renumbered[old_id] for old_id in extreme_cluster_idx],
+        # Center indices cover only the clusters clustering produced; the
+        # extremes get theirs appended later and always hold their own period.
+        None
+        if cluster_center_indices is None
+        else [
+            cluster_center_indices[old_id]
+            for old_id in kept_ids
+            if old_id < len(cluster_center_indices)
+        ],
+    )
+
+
 def _representatives_to_dataframe(
     cluster_periods_list: list[np.ndarray],
     column_index: pd.MultiIndex,
@@ -506,6 +558,7 @@ def refine_representatives(
     period_profiles = prepared.period_profiles
     cluster_periods_list = assignment.cluster_periods_list
     cluster_order = assignment.cluster_order
+    cluster_center_indices = assignment.cluster_center_indices
 
     # Add extreme periods if configured
     # Extremes run in weighted space (matching develop): weighted profiles
@@ -532,6 +585,17 @@ def refine_representatives(
             cfg.extremes,
         )
         cluster_order = np.asarray(extended_order)
+        (
+            cluster_periods_list,
+            cluster_order,
+            extreme_cluster_idx,
+            cluster_center_indices,
+        ) = _drop_empty_clusters(
+            cluster_periods_list,
+            cluster_order,
+            extreme_cluster_idx,
+            cluster_center_indices,
+        )
     else:
         if cfg.predef is not None and cfg.predef.extreme_cluster_idx is not None:
             extreme_cluster_idx = list(cfg.predef.extreme_cluster_idx)
@@ -602,7 +666,7 @@ def refine_representatives(
         normalized_typical_periods=normalized_typical_periods,
         cluster_order=cluster_order,
         cluster_counts=cluster_counts,
-        cluster_center_indices=assignment.cluster_center_indices,
+        cluster_center_indices=cluster_center_indices,
         extreme_cluster_idx=extreme_cluster_idx,
         extreme_periods=extreme_periods,
         rescale_deviations=rescale_deviations,

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -276,9 +276,9 @@ class AggregationResult:
     def n_clusters(self) -> int:
         """Number of clusters (typical periods).
 
-        Derived from the cluster_representatives DataFrame index,
-        which is the authoritative source. Note: cluster_counts may
-        have more entries than actual cluster IDs due to tsam quirks.
+        Counted from the cluster_representatives index. Empty clusters are
+        dropped when the clustering is built, so this agrees with
+        :attr:`ClusteringResult.n_clusters`.
         """
         return int(self.cluster_representatives.index.get_level_values(0).nunique())
 

--- a/test/test_empty_clusters.py
+++ b/test/test_empty_clusters.py
@@ -12,6 +12,7 @@ import pytest
 
 from conftest import TESTDATA_CSV
 from tsam import ClusterConfig, ExtremeConfig, aggregate
+from tsam.algorithms.clustering import assign_clusters
 from tsam.algorithms.representations import representations
 
 # The combination that empties a regular cluster on this dataset: the
@@ -71,3 +72,73 @@ def test_representations_rejects_a_label_space_with_holes():
             representation_dict=None,
             n_timesteps_per_period=4,
         )
+
+
+# --- clustering alone, no extremes configured -----------------------------
+#
+# Twenty days over three distinct day shapes. No clustering method can fill
+# eight clusters from three shapes, so some are left empty — with no
+# ExtremeConfig anywhere in sight.
+SHAPE_STARVED_CASE = {
+    "n_clusters": 8,
+    "cluster": ClusterConfig(method="kmaxoids", representation="mean"),
+}
+
+
+@pytest.fixture
+def three_shapes():
+    index = pd.date_range("2020-01-01", periods=24 * 20, freq="h")
+    values = np.concatenate([[1.0, 5.0, 9.0][i % 3] * np.ones(24) for i in range(20)])
+    return pd.DataFrame({"x": values, "y": values * 2}, index=index)
+
+
+def test_clustering_alone_cannot_leave_a_hole(three_shapes):
+    np.random.seed(0)  # kmaxoids draws from numpy.random
+    with pytest.warns(UserWarning, match="non-empty clusters"):
+        result = aggregate(three_shapes, **SHAPE_STARVED_CASE)
+
+    used_labels = {int(label) for label in result.cluster_assignments}
+
+    assert used_labels == set(range(result.n_clusters))
+    assert result.n_clusters == result.clustering.n_clusters
+    assert result.n_clusters < SHAPE_STARVED_CASE["n_clusters"]
+    # Every period is still accounted for by exactly one cluster.
+    assert sum(result.cluster_counts.values()) == pytest.approx(20)
+
+
+@pytest.mark.parametrize("preserve_column_means", [True, False])
+def test_shape_starved_clustering_still_transfers(three_shapes, preserve_column_means):
+    np.random.seed(0)
+    with pytest.warns(UserWarning, match="non-empty clusters"):
+        result = aggregate(
+            three_shapes,
+            preserve_column_means=preserve_column_means,
+            **SHAPE_STARVED_CASE,
+        )
+
+    transferred = result.clustering.apply(three_shapes)
+
+    assert transferred.n_clusters == result.n_clusters
+    np.testing.assert_array_equal(
+        transferred.cluster_assignments, result.cluster_assignments
+    )
+
+
+def test_assign_clusters_closes_gaps_in_the_label_space():
+    # Three distinct rows, eight clusters asked for: kmaxoids cannot fill them.
+    candidates = np.repeat([[0.0, 0.0], [5.0, 5.0], [9.0, 9.0]], 4, axis=0)
+
+    np.random.seed(0)
+    order = assign_clusters(candidates, n_clusters=8, cluster_method="kmaxoids")
+
+    labels = np.unique(order)
+    np.testing.assert_array_equal(labels, np.arange(labels.size))
+    assert labels.size < 8
+
+
+def test_assign_clusters_leaves_a_dense_label_space_alone():
+    candidates = np.repeat([[0.0, 0.0], [5.0, 5.0], [9.0, 9.0]], 4, axis=0)
+
+    order = assign_clusters(candidates, n_clusters=3, cluster_method="hierarchical")
+
+    np.testing.assert_array_equal(np.unique(order), np.arange(3))

--- a/test/test_empty_clusters.py
+++ b/test/test_empty_clusters.py
@@ -1,0 +1,73 @@
+"""Empty clusters must never leave the pipeline.
+
+``method="new_cluster"`` reassigns every period that sits closer to an extreme
+profile than to its own center, and nothing stops it from taking all of them.
+The cluster it empties used to survive with a representative standing for no
+periods, which put a hole in the label space (issues #478 and #480).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from conftest import TESTDATA_CSV
+from tsam import ClusterConfig, ExtremeConfig, aggregate
+from tsam.algorithms.representations import representations
+
+# The combination that empties a regular cluster on this dataset: the
+# distribution_minmax representatives are extreme enough for the peak-Load day
+# to absorb every member of one cluster.
+EMPTYING_CASE = {
+    "n_clusters": 8,
+    "period_duration": 24,
+    "cluster": ClusterConfig(
+        method="hierarchical", representation="distribution_minmax"
+    ),
+    "extremes": ExtremeConfig(method="new_cluster", max_value=["Load"]),
+}
+
+
+@pytest.fixture
+def raw():
+    return pd.read_csv(TESTDATA_CSV, index_col=0)
+
+
+def test_every_cluster_represents_at_least_one_period(raw):
+    result = aggregate(raw, **EMPTYING_CASE)
+
+    representative_ids = set(
+        result.cluster_representatives.index.get_level_values(0).unique().tolist()
+    )
+    used_labels = {int(label) for label in result.cluster_assignments}
+
+    assert representative_ids == used_labels
+    assert representative_ids == set(range(len(representative_ids)))
+    assert result.n_clusters == result.clustering.n_clusters
+
+
+def test_clustering_that_dropped_a_cluster_still_transfers(raw):
+    for preserve_column_means in (True, False):
+        result = aggregate(
+            raw, preserve_column_means=preserve_column_means, **EMPTYING_CASE
+        )
+        transferred = result.clustering.apply(raw)
+
+        assert transferred.n_clusters == result.n_clusters
+        np.testing.assert_array_equal(
+            transferred.cluster_assignments, result.cluster_assignments
+        )
+
+
+def test_representations_rejects_a_label_space_with_holes():
+    candidates = np.arange(6 * 4, dtype=float).reshape(6, 4)
+    order = np.array([0, 0, 1, 1, 3, 3])  # label 2 unused, 3 is the highest
+
+    with pytest.raises(ValueError, match="every label from 0 to 3"):
+        representations(
+            candidates,
+            order,
+            default="mean",
+            representation_method="mean",
+            representation_dict=None,
+            n_timesteps_per_period=4,
+        )

--- a/test/test_extremePeriods.py
+++ b/test/test_extremePeriods.py
@@ -83,7 +83,8 @@ def test_new_cluster_emptying_a_regular_cluster():
 
     The emptied cluster is then missing from the occurrence counts, which used
     to leave rescaling with a weighting vector too short to index by cluster id
-    (issue #478).
+    (issue #478). Such a cluster is now dropped before rescaling runs, so the
+    label space stays dense; test_empty_clusters.py covers that invariant.
     """
     raw = pd.read_csv(TESTDATA_CSV, index_col=0)
 
@@ -99,8 +100,9 @@ def test_new_cluster_emptying_a_regular_cluster():
         ),
     )
 
-    occupied = set(np.unique(aggregation.cluster_assignments).tolist())
-    assert len(occupied) < aggregation.n_clusters, (
+    # Two extremes on top of 8 clusters would be 10; one fewer means a regular
+    # cluster lost every period to them and was dropped.
+    assert aggregation.n_clusters < 10, (
         "expected this configuration to empty a regular cluster"
     )
 


### PR DESCRIPTION
Closes #480. **Stacked on #479** — based on `fix/rescale-empty-cluster`, so until that merges this PR's diff contains its commit too. Review its second commit only; the diff narrows on its own once #479 lands.

## What was wrong

All three defects in #480 come from one state: `method="new_cluster"` reassigns every period closer to an extreme profile than to its own center, and nothing stops it taking all of them. The emptied cluster kept a representative standing for no periods, leaving a hole in the label space.

Cluster ids are positions everywhere downstream — representatives live in a list indexed by id, and `representations()` returns one center per *observed* label. A hole misaligns every cluster above it. #479 stopped `aggregate()` crashing on that state; everything downstream of the returned object still broke.

I reproduced all three on `190eec2` before changing anything:

```
representative ids          : [0, 1, 2, 3, 4, 5, 6, 7, 8]
labels present in assignment: [0, 1, 2, 3, 4,    6, 7, 8]

result.n_clusters = 9   result.clustering.n_clusters = 8
apply(), preserve_column_means=True  -> IndexError: index 8 is out of bounds for axis 0 with size 8
apply(), preserve_column_means=False -> KeyError: '[8] not in index'
```

## The decision

#480 asks whether a stored label space with gaps should be **preserved** or **normalised**. This normalises, for a reason specific to what an empty cluster is: it has no members, so on transfer there is nothing to compute a representative *from*. Preserving the gap would mean faithfully replaying a representative that stands for nothing. There is no information to lose by dropping it.

So empty clusters are removed where they are created, renumbering the assignment, the extreme cluster ids and the stored center indices. Ids stay dense, and an id is always a valid position again.

The visible consequence: this configuration now returns 8 typical periods where it returned 9. That is the honest count — the ninth represented no periods and contributed nothing to the reconstruction. It also settles the question #478 left open, and makes both `n_clusters` properties agree by construction rather than by coincidence.

## Defect 2: fixed by construction, not by a guard

Dense ids make it unreachable — `rescale_representatives` can no longer be handed an extreme id without a representative. I had added a precondition there too and took it back out: it guards a state that the only remaining caller cannot produce, and #479 already made that line id-safe.

Defect 1 does keep a guard, because it stays reachable: a clustering stored *before* this change still has a hole in its label space, and `representations()` would silently renumber it — returning 3 centers for labels `[0, 1, 3]`, so cluster 3 reads cluster 2's profile. There is no representative to compute for a cluster with no members, so it now refuses the input with a sentence naming the problem instead of failing later inside numpy.

## Note on #479

After this change, the line #479 fixed is no longer reachable from `aggregate()` — empty clusters are dropped before rescaling runs. #479 is still correct and worth keeping: it is what makes `rescale_representatives` sane for a direct caller, and it is the smaller, more backportable fix of the two. But its regression test asserted that an empty cluster *survives*, which is now false, so this PR rewrites that assertion to check the cluster count instead. Worth knowing if you were planning to merge them in either order — this one depends on #479's branch but not on its fix.

## Verification

- New `test/test_empty_clusters.py`: 3 tests covering the dense label space and the two `n_clusters` agreeing, transfer under both `preserve_column_means` settings, and the `representations()` guard. All three confirmed red on `190eec2`.
- Full suite: 699 passed, 145 skipped, 5 xfailed, 1 xpassed — no regressions, no golden-data changes. The xpass (`test_partial_weights_accuracy`) is pre-existing on `develop`.
- #480 notes that #414 marks this combination `xfail(strict=True)` in `TestTransferExactness`. That marker is on #414's branch, not `develop`, so it is not removed here — it will need removing when #414 rebases.
